### PR TITLE
Module renaming of Ruby Smart driver

### DIFF
--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -19,7 +19,7 @@ jobs:
           ruby-version: "3.2"
 
       - name: Build source gem
-        run: gem build pg.gemspec
+        run: gem build yugabyte_ysql.gemspec
 
       - name: Upload source gem
         uses: actions/upload-artifact@v3

--- a/.irbrc
+++ b/.irbrc
@@ -15,7 +15,7 @@ BEGIN {
 # Try to require the 'pg' library
 begin
 	$stderr.puts "Loading pg..."
-	require 'pg'
+	require 'yugabyte_ysql'
 rescue => e
 	$stderr.puts "Ack! pg library failed to load: #{e.message}\n\t" +
 		e.backtrace.join( "\n\t" )

--- a/.pryrc
+++ b/.pryrc
@@ -15,7 +15,7 @@ BEGIN {
 # Try to require the 'pg' library
 begin
 	$stderr.puts "Loading pg..."
-	require 'pg'
+	require 'yugabyte_ysql'
 rescue => e
 	$stderr.puts "Ack! pg library failed to load: #{e.message}\n\t" +
 		e.backtrace.join( "\n\t" )

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # -*- ruby -*-
 
-# Specify your gem's runtime dependencies in pg.gemspec
+# Specify your gem's runtime dependencies in yugabyte_ysql.gemspec
 gemspec
 
 source "https://rubygems.org/"

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,13 +15,14 @@ RDBMS](http://www.postgresql.org/)へのRubyのインターフェースです。
 9.3以降](http://www.postgresql.org/support/versioning/)で動作します。
 
 簡単な使用例は次の通りです。
+
 ```ruby
   #!/usr/bin/env ruby
 
   require 'pg'
 
   # データベースへの現在の接続を表に出力します
-  conn = PG.connect( dbname: 'sales' )
+  conn = YugabyteYSQL.connect( dbname: 'sales' )
   conn.exec( "SELECT * FROM pg_stat_activity" ) do |result|
     puts "     PID | User             | Query"
     result.each do |row|
@@ -88,16 +89,17 @@ Pgでは任意でRubyと素のCコードにある結果の値やクエリ引数�
 なぜなら文字列のアロケーションが減り、（比較的遅い）Rubyのコードでの変換部分が省かれるからです。
 
 とても基本的な型変換は次のようにできます。
-```ruby
-    conn.type_map_for_results = PG::BasicTypeMapForResults.new conn
-    # ……これは結果の値の対応付けに作用します。
-    conn.exec("select 1, now(), '{2,3}'::int[]").values
-        # => [[1, 2014-09-21 20:51:56 +0200, [2, 3]]]
 
-    conn.type_map_for_queries = PG::BasicTypeMapForQueries.new conn
-    # ……そしてこれは引数値の対応付けのためのものです。
-    conn.exec_params("SELECT $1::text, $2::text, $3::text", [1, 1.23, [2,3]]).values
-        # => [["1", "1.2300000000000000E+00", "{2,3}"]]
+```ruby
+    conn.type_map_for_results = YugabyteYSQL::BasicTypeMapForResults.new conn
+# ……これは結果の値の対応付けに作用します。
+conn.exec("select 1, now(), '{2,3}'::int[]").values
+# => [[1, 2014-09-21 20:51:56 +0200, [2, 3]]]
+
+conn.type_map_for_queries = YugabyteYSQL::BasicTypeMapForQueries.new conn
+# ……そしてこれは引数値の対応付けのためのものです。
+conn.exec_params("SELECT $1::text, $2::text, $3::text", [1, 1.23, [2, 3]]).values
+# => [["1", "1.2300000000000000E+00", "{2,3}"]]
 ```
 
 しかしPgの型変換はかなり調整が効きます。2層に分かれているのがその理由です。

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# pg_yugabytedb
+# yugabyte_ysql
 
 This is a fork of [Ruby interface to the PostgreSQL RDBMS](https://github.com/ged/ruby-pg) to develop a Ruby interface to YugabyteDB.
 
 ## Features
 
-This driver has the following features:
+This driver has the following features in addition to those that come with the upstream driver:
 
 ### Cluster Awareness to eliminate need for a load balancer
 
@@ -24,21 +24,33 @@ This is similar to 'Cluster Awareness' but uses those servers which are part of 
 
 Please refer to the [Use the Driver](#Use the Driver) section for examples.
 
+## Install the Driver
+
+```shell
+gem install -- --with-pg-config=<yugabyte-install-dir>/postgres/bin/pg_config
+```
+
 ## Use the Driver
 
 - Passing new connection properties for load balancing in connection url
 
   For uniform load balancing across all the server you just need to specify the _load_balance=true_ property in the url.
     ```
+    require 'yugabyte_ysql'
+    ...
     yburl = "postgresql://yugabyte:yugabyte@127.0.0.1:5433/yugabyte?load_balance=true"
-    connection = PG.connect(url)
+    connection = YugabyteYSQL.connect(url)
+    ...
     ```
 
   For specifying topology keys you need to set the additional property with a valid comma separated value.
 
     ```
+    require 'yugabyte_ysql'
+    ...
     yburl = "postgresql://yugabyte:yugabyte@127.0.0.1:5433/yugabyte?load_balance=true&topology_keys=cloud.regionA.zoneA,cloud.regionA.zoneB"
-    connection = PG.connect(url)
+    connection = YugabyteYSQL.connect(url)
+    ...
     ```
 
 ### Specifying fallback zones
@@ -63,8 +75,15 @@ The driver attempts connection to servers in the first fallback placement(s) if 
 then it attempts to connect to servers in the second fallback placement(s), if specified. This continues until the driver finds a server to connect to, else an error is returned to the application.
 And this repeats for each connection request.
 
+### Limitations
+
+- The load balancing feature of the Ruby Smart driver for YugabyteDB does not work with ActiveRecords - the ORM tool for Ruby apps.
 
 Rest of the README is from upstream repository.
+
+---
+
+# pg
 
 * home :: https://github.com/ged/ruby-pg
 * docs :: http://deveiate.org/code/pg (English) ,

--- a/README.md
+++ b/README.md
@@ -80,20 +80,21 @@ Pg is the Ruby interface to the [PostgreSQL RDBMS](http://www.postgresql.org/).
 It works with [PostgreSQL 9.3 and later](http://www.postgresql.org/support/versioning/).
 
 A small example usage:
+
 ```ruby
   #!/usr/bin/env ruby
 
-  require 'pg'
+require 'pg'
 
-  # Output a table of current connections to the DB
-  conn = PG.connect( dbname: 'sales' )
-  conn.exec( "SELECT * FROM pg_stat_activity" ) do |result|
-    puts "     PID | User             | Query"
-    result.each do |row|
-      puts " %7d | %-16s | %s " %
-        row.values_at('pid', 'usename', 'query')
-    end
+# Output a table of current connections to the DB
+conn = YugabyteYSQL.connect(dbname: 'sales')
+conn.exec("SELECT * FROM pg_stat_activity") do |result|
+  puts "     PID | User             | Query"
+  result.each do |row|
+    puts " %7d | %-16s | %s " %
+                 row.values_at('pid', 'usename', 'query')
   end
+end
 ```
 
 ## Build Status
@@ -159,16 +160,17 @@ because String allocations are reduced and conversions in (slower) Ruby code
 can be omitted.
 
 Very basic type casting can be enabled by:
-```ruby
-    conn.type_map_for_results = PG::BasicTypeMapForResults.new conn
-    # ... this works for result value mapping:
-    conn.exec("select 1, now(), '{2,3}'::int[]").values
-        # => [[1, 2014-09-21 20:51:56 +0200, [2, 3]]]
 
-    conn.type_map_for_queries = PG::BasicTypeMapForQueries.new conn
-    # ... and this for param value mapping:
-    conn.exec_params("SELECT $1::text, $2::text, $3::text", [1, 1.23, [2,3]]).values
-        # => [["1", "1.2300000000000000E+00", "{2,3}"]]
+```ruby
+    conn.type_map_for_results = YugabyteYSQL::BasicTypeMapForResults.new conn
+# ... this works for result value mapping:
+conn.exec("select 1, now(), '{2,3}'::int[]").values
+# => [[1, 2014-09-21 20:51:56 +0200, [2, 3]]]
+
+conn.type_map_for_queries = YugabyteYSQL::BasicTypeMapForQueries.new conn
+# ... and this for param value mapping:
+conn.exec_params("SELECT $1::text, $2::text, $3::text", [1, 1.23, [2, 3]]).values
+# => [["1", "1.2300000000000000E+00", "{2,3}"]]
 ```
 
 But Pg's type casting is highly customizable. That's why it's divided into

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ TESTDIR = BASEDIR + "tmp_test_*"
 DLEXT   = RbConfig::CONFIG['DLEXT']
 EXT     = LIBDIR + "pg_ext.#{DLEXT}"
 
-GEMSPEC = 'pg.gemspec'
+GEMSPEC = 'yugabyte_ysql.gemspec'
 
 CLEAN.include( TESTDIR.to_s )
 CLEAN.include( PKGDIR.to_s, TMPDIR.to_s )
@@ -89,7 +89,7 @@ task :gem => :build
 task :clobber do
 	puts "Stop any Postmaster instances that remain after testing."
 	require_relative 'spec/helpers'
-	PG::TestingHelpers.stop_existing_postmasters()
+	YugabyteYSQL::TestingHelpers.stop_existing_postmasters()
 end
 
 desc "Update list of server error codes"

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -69,7 +69,7 @@ end
 $stderr.puts "Using libpq from #{dlldir}"
 
 File.write("postgresql_lib_path.rb", <<-EOT)
-module PG
+module YugabyteYSQL
 	POSTGRESQL_LIB_PATH = #{dlldir.inspect}
 end
 EOT

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -346,7 +346,7 @@ Init_pg_ext(void)
 		pg_skip_deprecation_warning = 0;
 	}
 
-	rb_mPG = rb_define_module( "PG" );
+	rb_mPG = rb_define_module( "YugabyteYSQL" );
 	rb_mPGconstants = rb_define_module_under( rb_mPG, "Constants" );
 
 	/*************************

--- a/lib/pg/basic_type_map_based_on_result.rb
+++ b/lib/pg/basic_type_map_based_on_result.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
 # Simple set of rules for type casting common PostgreSQL types from Ruby
 # to PostgreSQL.
@@ -53,8 +53,8 @@ require 'pg' unless defined?( PG )
 # database types using binary copy and value format.
 # Binary COPY is faster than text format but less portable and less readable and pg offers fewer en-/decoders of database types.
 #
-class PG::BasicTypeMapBasedOnResult < PG::TypeMapByOid
-	include PG::BasicTypeRegistry::Checker
+class YugabyteYSQL::BasicTypeMapBasedOnResult < YugabyteYSQL::TypeMapByOid
+	include YugabyteYSQL::BasicTypeRegistry::Checker
 
 	def initialize(connection_or_coder_maps, registry: nil)
 		@coder_maps = build_coder_maps(connection_or_coder_maps, registry: registry)

--- a/lib/pg/basic_type_map_for_queries.rb
+++ b/lib/pg/basic_type_map_for_queries.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
 # Simple set of rules for type casting common Ruby types to PostgreSQL.
 #
@@ -21,7 +21,7 @@ require 'pg' unless defined?( PG )
 #   # Execute a query. The Integer param value is typecasted internally by PG::BinaryEncoder::Int8.
 #   # The format of the parameter is set to 0 (text) and the OID of this parameter is set to 20 (int8).
 #   res = conn.exec_params( "SELECT $1", [5] )
-class PG::BasicTypeMapForQueries < PG::TypeMapByClass
+class YugabyteYSQL::BasicTypeMapForQueries < YugabyteYSQL::TypeMapByClass
 	# Helper class for submission of binary strings into bytea columns.
 	#
 	# Since PG::BasicTypeMapForQueries chooses the encoder to be used by the class of the submitted value,
@@ -40,7 +40,7 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 	class UndefinedEncoder < RuntimeError
 	end
 
-	include PG::BasicTypeRegistry::Checker
+	include YugabyteYSQL::BasicTypeRegistry::Checker
 
 	# Create a new type map for query submission
 	#
@@ -132,9 +132,9 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 					when :array
 						self[klass] = selector
 					when :json
-						self[klass] = PG::TextEncoder::JSON.new
+						self[klass] = YugabyteYSQL::TextEncoder::JSON.new
 					when :record
-						self[klass] = PG::TextEncoder::Record.new type_map: self
+						self[klass] = YugabyteYSQL::TextEncoder::Record.new type_map: self
 					when /\A_/
 						coder = coder_by_name(0, :encoder, @encode_array_as)
 						if coder
@@ -172,7 +172,7 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 	rescue LoadError
 	end
 
-	DEFAULT_TYPE_MAP = PG.make_shareable({
+	DEFAULT_TYPE_MAP = YugabyteYSQL.make_shareable({
 		TrueClass => [1, 'bool', 'bool'],
 		FalseClass => [1, 'bool', 'bool'],
 		# We use text format and no type OID for numbers, because setting the OID can lead
@@ -189,7 +189,7 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 	}.merge(has_bigdecimal ? {BigDecimal => [0, 'numeric']} : {}))
 	private_constant :DEFAULT_TYPE_MAP
 
-	DEFAULT_ARRAY_TYPE_MAP = PG.make_shareable({
+	DEFAULT_ARRAY_TYPE_MAP = YugabyteYSQL.make_shareable({
 		TrueClass => [0, '_bool'],
 		FalseClass => [0, '_bool'],
 		Integer => [0, '_int8'],

--- a/lib/pg/basic_type_map_for_results.rb
+++ b/lib/pg/basic_type_map_for_results.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
 # Simple set of rules for type casting common PostgreSQL types to Ruby.
 #
@@ -67,10 +67,10 @@ require 'pg' unless defined?( PG )
 #   ["a", 123, 2023-03-19 18:39:44 UTC]
 #
 # See also PG::BasicTypeMapBasedOnResult for the encoder direction and PG::BasicTypeRegistry for the definition of additional types.
-class PG::BasicTypeMapForResults < PG::TypeMapByOid
-	include PG::BasicTypeRegistry::Checker
+class YugabyteYSQL::BasicTypeMapForResults < YugabyteYSQL::TypeMapByOid
+	include YugabyteYSQL::BasicTypeRegistry::Checker
 
-	class WarningTypeMap < PG::TypeMapInRuby
+	class WarningTypeMap < YugabyteYSQL::TypeMapInRuby
 		def initialize(typenames)
 			@already_warned = {}
 			@typenames_by_oid = typenames

--- a/lib/pg/binary_decoder/date.rb
+++ b/lib/pg/binary_decoder/date.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module BinaryDecoder
 		# Init C part of the decoder
 		init_date

--- a/lib/pg/binary_decoder/timestamp.rb
+++ b/lib/pg/binary_decoder/timestamp.rb
@@ -1,25 +1,25 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module BinaryDecoder
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_UTC)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 	end

--- a/lib/pg/binary_encoder/timestamp.rb
+++ b/lib/pg/binary_encoder/timestamp.rb
@@ -1,19 +1,19 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module BinaryEncoder
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL)
 			end
 		end
 	end

--- a/lib/pg/coder.rb
+++ b/lib/pg/coder.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 
 	class Coder
 

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 require 'io/wait' unless ::IO.public_instance_methods(false).include?(:wait_readable)
 require 'socket'
 require_relative 'load_balance_service'
@@ -28,7 +28,7 @@ require_relative 'load_balance_service'
 # 3. #sync_exec - the method version that is implemented by blocking function(s) of libpq.
 #
 # Sync and async version of the method can be switched by Connection.async_api= , however it is not recommended to change the default.
-class PG::Connection
+class YugabyteYSQL::Connection
 
 	# The order the options are passed to the ::connect method.
 	CONNECT_ARGUMENT_ORDER = %w[host port options tty dbname user password load_balance topology_keys yb_servers_refresh_interval fallback_to_topology_keys_only failed_host_reconnect_delay_secs].freeze
@@ -81,8 +81,8 @@ class PG::Connection
 				# Option or URL string style
 				conn_string = args.first.to_s
 				# extract and parse lb properties from conn_string
-				conn_string, lb_props = PG::LoadBalanceService.parse_lb_args_from_url conn_string
-				iopts = PG::Connection.conninfo_parse(conn_string).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
+				conn_string, lb_props = YugabyteYSQL::LoadBalanceService.parse_lb_args_from_url conn_string
+				iopts = YugabyteYSQL::Connection.conninfo_parse(conn_string).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
 			else
 				# Positional parameters (only host given)
 				iopts[CONNECT_ARGUMENT_ORDER.first.to_sym] = args.first
@@ -99,7 +99,7 @@ class PG::Connection
 			iopts.delete(:tty) # ignore obsolete tty parameter
 		end
 
-		lb_props = PG::LoadBalanceService.parse_connect_lb_args hash_arg unless hash_arg.empty?
+		lb_props = YugabyteYSQL::LoadBalanceService.parse_connect_lb_args hash_arg unless hash_arg.empty?
 
 		iopts.merge!( hash_arg )
 
@@ -117,13 +117,13 @@ class PG::Connection
 			" finished"
 		else
 			stats = []
-			stats << " status=#{ PG.constants.grep(/CONNECTION_/).find{|c| PG.const_get(c) == status} }" if status != CONNECTION_OK
-			stats << " transaction_status=#{ PG.constants.grep(/PQTRANS_/).find{|c| PG.const_get(c) == transaction_status} }" if transaction_status != PG::PQTRANS_IDLE
+			stats << " status=#{ YugabyteYSQL.constants.grep(/CONNECTION_/).find{|c| YugabyteYSQL.const_get(c) == status} }" if status != CONNECTION_OK
+			stats << " transaction_status=#{ YugabyteYSQL.constants.grep(/PQTRANS_/).find{|c| YugabyteYSQL.const_get(c) == transaction_status} }" if transaction_status != YugabyteYSQL::PQTRANS_IDLE
 			stats << " nonblocking=#{ isnonblocking }" if isnonblocking
-			stats << " pipeline_status=#{ PG.constants.grep(/PQ_PIPELINE_/).find{|c| PG.const_get(c) == pipeline_status} }" if respond_to?(:pipeline_status) && pipeline_status != PG::PQ_PIPELINE_OFF
+			stats << " pipeline_status=#{ YugabyteYSQL.constants.grep(/PQ_PIPELINE_/).find{|c| YugabyteYSQL.const_get(c) == pipeline_status} }" if respond_to?(:pipeline_status) && pipeline_status != YugabyteYSQL::PQ_PIPELINE_OFF
 			stats << " client_encoding=#{ get_client_encoding }" if get_client_encoding != "UTF8"
-			stats << " type_map_for_results=#{ type_map_for_results.to_s }" unless type_map_for_results.is_a?(PG::TypeMapAllStrings)
-			stats << " type_map_for_queries=#{ type_map_for_queries.to_s }" unless type_map_for_queries.is_a?(PG::TypeMapAllStrings)
+			stats << " type_map_for_results=#{ type_map_for_results.to_s }" unless type_map_for_results.is_a?(YugabyteYSQL::TypeMapAllStrings)
+			stats << " type_map_for_queries=#{ type_map_for_queries.to_s }" unless type_map_for_queries.is_a?(YugabyteYSQL::TypeMapAllStrings)
 			stats << " encoder_for_put_copy_data=#{ encoder_for_put_copy_data.to_s }" if encoder_for_put_copy_data
 			stats << " decoder_for_get_copy_data=#{ decoder_for_get_copy_data.to_s }" if decoder_for_get_copy_data
 			" host=#{host} port=#{port} user=#{user}#{stats.join}"
@@ -223,7 +223,7 @@ class PG::Connection
 	#   ["more", "data", "to", "copy"]
 
 	def copy_data( sql, coder=nil )
-		raise PG::NotInBlockingMode.new("copy_data can not be used in nonblocking mode", connection: self) if nonblocking?
+		raise YugabyteYSQL::NotInBlockingMode.new("copy_data can not be used in nonblocking mode", connection: self) if nonblocking?
 		res = exec( sql )
 
 		case res.result_status
@@ -244,7 +244,7 @@ class PG::Connection
 				errmsg = "%s while copy data: %s" % [ err.class.name, err.message ]
 				begin
 					put_copy_end( errmsg )
-				rescue PG::Error
+				rescue YugabyteYSQL::Error
 					# Ignore error in cleanup to avoid losing original exception
 				end
 				discard_results
@@ -258,8 +258,8 @@ class PG::Connection
 					end
 
 					put_copy_end
-				rescue PG::Error => err
-					raise PG::LostCopyState.new("#{err} (probably by executing another SQL query while running a COPY command)", connection: self)
+				rescue YugabyteYSQL::Error => err
+					raise YugabyteYSQL::LostCopyState.new("#{err} (probably by executing another SQL query while running a COPY command)", connection: self)
 				end
 				get_last_result
 			ensure
@@ -283,16 +283,16 @@ class PG::Connection
 					# The file trailer is expected to be processed by BinaryDecoder::CopyRow and already returns nil, so that the remaining NULL from PQgetCopyData is retrieved here:
 					if get_copy_data
 						discard_results
-						raise PG::NotAllCopyDataRetrieved.new("Not all binary COPY data retrieved", connection: self)
+						raise YugabyteYSQL::NotAllCopyDataRetrieved.new("Not all binary COPY data retrieved", connection: self)
 					end
 				end
 				res = get_last_result
 				if !res
 					discard_results
-					raise PG::LostCopyState.new("Lost COPY state (probably by executing another SQL query while running a COPY command)", connection: self)
+					raise YugabyteYSQL::LostCopyState.new("Lost COPY state (probably by executing another SQL query while running a COPY command)", connection: self)
 				elsif res.result_status != PGRES_COMMAND_OK
 					discard_results
-					raise PG::NotAllCopyDataRetrieved.new("Not all COPY data retrieved", connection: self)
+					raise YugabyteYSQL::NotAllCopyDataRetrieved.new("Not all COPY data retrieved", connection: self)
 				end
 				res
 			ensure
@@ -306,7 +306,7 @@ class PG::Connection
 
 	# Backward-compatibility aliases for stuff that's moved into PG.
 	class << self
-		define_method( :isthreadsafe, &PG.method(:isthreadsafe) )
+		define_method( :isthreadsafe, &YugabyteYSQL.method(:isthreadsafe) )
 	end
 
 	#
@@ -322,7 +322,7 @@ class PG::Connection
 		yield(self)
 	rescue Exception
 		rollback = true
-		cancel if transaction_status == PG::PQTRANS_ACTIVE
+		cancel if transaction_status == YugabyteYSQL::PQTRANS_ACTIVE
 		block
 		exec "ROLLBACK"
 		raise
@@ -580,7 +580,7 @@ class PG::Connection
 	# backend connection and tries to re-connect.
 	def reset
 		iopts = conninfo_hash.compact
-		if iopts[:host] && !iopts[:host].empty? && PG.library_version >= 100000
+		if iopts[:host] && !iopts[:host].empty? && YugabyteYSQL.library_version >= 100000
 			iopts = self.class.send(:resolve_hosts, iopts)
 		end
 		conninfo = self.class.parse_connect_args( iopts );
@@ -663,9 +663,9 @@ class PG::Connection
 			stop_time = timeo * host_count + Process.clock_gettime(Process::CLOCK_MONOTONIC)
 		end
 
-		poll_status = PG::PGRES_POLLING_WRITING
-		until poll_status == PG::PGRES_POLLING_OK ||
-				poll_status == PG::PGRES_POLLING_FAILED
+		poll_status = YugabyteYSQL::PGRES_POLLING_WRITING
+		until poll_status == YugabyteYSQL::PGRES_POLLING_OK ||
+				poll_status == YugabyteYSQL::PGRES_POLLING_FAILED
 
 			# Set single timeout to parameter "connect_timeout" but
 			# don't exceed total connection time of number-of-hosts * connect_timeout.
@@ -673,7 +673,7 @@ class PG::Connection
 			event = if !timeout || timeout >= 0
 				# If the socket needs to read, wait 'til it becomes readable to poll again
 				case poll_status
-				when PG::PGRES_POLLING_READING
+				when YugabyteYSQL::PGRES_POLLING_READING
 					if defined?(IO::READABLE) # ruby-3.0+
 						socket_io.wait(IO::READABLE | IO::PRIORITY, timeout)
 					else
@@ -681,7 +681,7 @@ class PG::Connection
 					end
 
 				# ...and the same for when the socket needs to write
-				when PG::PGRES_POLLING_WRITING
+				when YugabyteYSQL::PGRES_POLLING_WRITING
 					if defined?(IO::WRITABLE) # ruby-3.0+
 						# Use wait instead of wait_readable, since connection errors are delivered as
 						# exceptional/priority events on Windows.
@@ -702,17 +702,17 @@ class PG::Connection
 				else
 					connhost = "at \"#{host}\", port #{port}"
 				end
-				raise PG::ConnectionBad.new("connection to server #{connhost} failed: timeout expired", connection: self)
+				raise YugabyteYSQL::ConnectionBad.new("connection to server #{connhost} failed: timeout expired", connection: self)
 			end
 
 			# Check to see if it's finished or failed yet
 			poll_status = send( poll_meth )
 		end
 
-		unless status == PG::CONNECTION_OK
+		unless status == YugabyteYSQL::CONNECTION_OK
 			msg = error_message
 			finish
-			raise PG::ConnectionBad.new(msg, connection: self)
+			raise YugabyteYSQL::ConnectionBad.new(msg, connection: self)
 		end
 
 		# Set connection to nonblocking to handle all blocking states in ruby.
@@ -800,7 +800,7 @@ class PG::Connection
 			iports = iopts[:port].split(",", -1)
 			iports = [nil] if iports.size == 0
 			iports = iports * ihosts.size if iports.size == 1
-			raise PG::ConnectionBad, "could not match #{iports.size} port numbers to #{ihosts.size} hosts" if iports.size != ihosts.size
+			raise YugabyteYSQL::ConnectionBad, "could not match #{iports.size} port numbers to #{ihosts.size} hosts" if iports.size != ihosts.size
 
 			dests = ihosts.each_with_index.flat_map do |mhost, idx|
 				unless host_is_named_pipe?(mhost)
@@ -828,13 +828,13 @@ class PG::Connection
 
 		private def connect_to_hosts(*args)
 			option_string, lb_properties = parse_connect_args_and_return_lb_props(*args)
-			iopts = PG::Connection.conninfo_parse(option_string).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
-			iopts = PG::Connection.conndefaults.each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }.merge(iopts)
+			iopts = YugabyteYSQL::Connection.conninfo_parse(option_string).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
+			iopts = YugabyteYSQL::Connection.conndefaults.each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }.merge(iopts)
 			original_host = iopts[:host]
 			original_port = iopts[:port]
 
 			if lb_properties
-				connection = PG::LoadBalanceService.connect_to_lb_hosts(lb_properties, iopts)
+				connection = YugabyteYSQL::LoadBalanceService.connect_to_lb_hosts(lb_properties, iopts)
 			end
 			if connection.nil?
 				if lb_properties
@@ -850,15 +850,15 @@ class PG::Connection
 			if iopts[:hostaddr]
 				# hostaddr is provided -> no need to resolve hostnames
 
-			elsif iopts[:host] && !iopts[:host].empty? && PG.library_version >= 100000
+			elsif iopts[:host] && !iopts[:host].empty? && YugabyteYSQL.library_version >= 100000
 				iopts = resolve_hosts(iopts)
 			else
 				# No host given
 			end
 			conn = self.connect_start(iopts) or
-										raise(PG::Error, "Unable to create a new connection")
+										raise(YugabyteYSQL::Error, "Unable to create a new connection")
 
-			raise PG::ConnectionBad, conn.error_message if conn.status == PG::CONNECTION_BAD
+			raise YugabyteYSQL::ConnectionBad, conn.error_message if conn.status == YugabyteYSQL::CONNECTION_BAD
 
 			conn.send(:async_connect_or_reset, :connect_poll)
 			conn
@@ -905,7 +905,7 @@ class PG::Connection
 		end
 		alias async_ping ping
 
-		REDIRECT_CLASS_METHODS = PG.make_shareable({
+		REDIRECT_CLASS_METHODS = YugabyteYSQL.make_shareable({
 			:new => [:async_connect, :sync_connect],
 			:connect => [:async_connect, :sync_connect],
 			:open => [:async_connect, :sync_connect],
@@ -916,7 +916,7 @@ class PG::Connection
 		private_constant :REDIRECT_CLASS_METHODS
 
 		# These methods are affected by PQsetnonblocking
-		REDIRECT_SEND_METHODS = PG.make_shareable({
+		REDIRECT_SEND_METHODS = YugabyteYSQL.make_shareable({
 			:isnonblocking => [:async_isnonblocking, :sync_isnonblocking],
 			:nonblocking? => [:async_isnonblocking, :sync_isnonblocking],
 			:put_copy_data => [:async_put_copy_data, :sync_put_copy_data],
@@ -943,12 +943,12 @@ class PG::Connection
 		}
 		private_constant :REDIRECT_METHODS
 
-		if PG::Connection.instance_methods.include? :async_encrypt_password
+		if YugabyteYSQL::Connection.instance_methods.include? :async_encrypt_password
 			REDIRECT_METHODS.merge!({
 				:encrypt_password => [:async_encrypt_password, :sync_encrypt_password],
 			})
 		end
-		PG.make_shareable(REDIRECT_METHODS)
+		YugabyteYSQL.make_shareable(REDIRECT_METHODS)
 
 		def async_send_api=(enable)
 			REDIRECT_SEND_METHODS.each do |ali, (async, sync)|

--- a/lib/pg/exceptions.rb
+++ b/lib/pg/exceptions.rb
@@ -1,10 +1,10 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
 
-module PG
+module YugabyteYSQL
 
 	class Error < StandardError
 		def initialize(msg=nil, connection: nil, result: nil)
@@ -14,11 +14,11 @@ module PG
 		end
 	end
 
-	class NotAllCopyDataRetrieved < PG::Error
+	class NotAllCopyDataRetrieved < YugabyteYSQL::Error
 	end
-	class LostCopyState < PG::Error
+	class LostCopyState < YugabyteYSQL::Error
 	end
-	class NotInBlockingMode < PG::Error
+	class NotInBlockingMode < YugabyteYSQL::Error
 	end
 
 end # module PG

--- a/lib/pg/result.rb
+++ b/lib/pg/result.rb
@@ -1,10 +1,10 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
 
-class PG::Result
+class YugabyteYSQL::Result
 
 	# Apply a type map for all value retrieving methods.
 	#

--- a/lib/pg/text_decoder/date.rb
+++ b/lib/pg/text_decoder/date.rb
@@ -3,7 +3,7 @@
 
 require 'date'
 
-module PG
+module YugabyteYSQL
 	module TextDecoder
 		class Date < SimpleDecoder
 			def decode(string, tuple=nil, field=nil)

--- a/lib/pg/text_decoder/inet.rb
+++ b/lib/pg/text_decoder/inet.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module TextDecoder
 		# Init C part of the decoder
 		init_inet

--- a/lib/pg/text_decoder/json.rb
+++ b/lib/pg/text_decoder/json.rb
@@ -3,7 +3,7 @@
 
 require 'json'
 
-module PG
+module YugabyteYSQL
 	module TextDecoder
 		class JSON < SimpleDecoder
 			def decode(string, tuple=nil, field=nil)

--- a/lib/pg/text_decoder/numeric.rb
+++ b/lib/pg/text_decoder/numeric.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module TextDecoder
 		# Init C part of the decoder
 		init_numeric

--- a/lib/pg/text_decoder/timestamp.rb
+++ b/lib/pg/text_decoder/timestamp.rb
@@ -1,25 +1,25 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module TextDecoder
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_UTC)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
-				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL)
+				super(**hash, **kwargs, flags: YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 

--- a/lib/pg/text_encoder/date.rb
+++ b/lib/pg/text_encoder/date.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module TextEncoder
 		class Date < SimpleEncoder
 			def encode(value)

--- a/lib/pg/text_encoder/inet.rb
+++ b/lib/pg/text_encoder/inet.rb
@@ -3,7 +3,7 @@
 
 require 'ipaddr'
 
-module PG
+module YugabyteYSQL
 	module TextEncoder
 		class Inet < SimpleEncoder
 			def encode(value)

--- a/lib/pg/text_encoder/json.rb
+++ b/lib/pg/text_encoder/json.rb
@@ -3,7 +3,7 @@
 
 require 'json'
 
-module PG
+module YugabyteYSQL
 	module TextEncoder
 		class JSON < SimpleEncoder
 			def encode(value)

--- a/lib/pg/text_encoder/numeric.rb
+++ b/lib/pg/text_encoder/numeric.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module TextEncoder
 		# Init C part of the decoder
 		init_numeric

--- a/lib/pg/text_encoder/timestamp.rb
+++ b/lib/pg/text_encoder/timestamp.rb
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-module PG
+module YugabyteYSQL
 	module TextEncoder
 		class TimestampWithoutTimeZone < SimpleEncoder
 			def encode(value)

--- a/lib/pg/tuple.rb
+++ b/lib/pg/tuple.rb
@@ -1,10 +1,10 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
 
-class PG::Tuple
+class YugabyteYSQL::Tuple
 
 	### Return a String representation of the object suitable for debugging.
 	def inspect

--- a/lib/pg/type_map_by_column.rb
+++ b/lib/pg/type_map_by_column.rb
@@ -1,9 +1,9 @@
 # -*- ruby -*-
 # frozen_string_literal: true
 
-require 'pg' unless defined?( PG )
+require 'yugabyte_ysql' unless defined?( YugabyteYSQL )
 
-class PG::TypeMapByColumn
+class YugabyteYSQL::TypeMapByColumn
 	# Returns the type oids of the assigned coders.
 	def oids
 		coders.map{|c| c.oid if c }

--- a/lib/pg/version.rb
+++ b/lib/pg/version.rb
@@ -1,5 +1,5 @@
 module YugabyteYSQL
 	# Library version
 	PG_VERSION = '1.5.6'
-	VERSION = '0.1'
+	VERSION = '0.2'
 end

--- a/lib/pg/version.rb
+++ b/lib/pg/version.rb
@@ -1,4 +1,5 @@
-module PG
+module YugabyteYSQL
 	# Library version
-	VERSION = '1.5.6'
+	PG_VERSION = '1.5.6'
+	VERSION = '0.1'
 end

--- a/lib/yugabyte_ysql.rb
+++ b/lib/yugabyte_ysql.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 # The top-level PG namespace.
-module PG
+module YugabyteYSQL
 
 	# Is this file part of a fat binary gem with bundled libpq?
 	bundled_libpq_path = File.join(__dir__, RUBY_PLATFORM.gsub(/^i386-/, "x86-"))

--- a/misc/openssl-pg-segfault.rb
+++ b/misc/openssl-pg-segfault.rb
@@ -6,9 +6,9 @@ PGDB     = 'test'
 SOCKHOST = 'it-trac.laika.com'
 
 # Load pg first, so the libssl.so that libpq is linked against is loaded.
-require 'pg'
+require 'yugabyte_ysql'
 $stderr.puts "connecting to postgres://#{PGHOST}/#{PGDB}"
-conn = PG.connect( PGHOST, :dbname => PGDB )
+conn = YugabyteYSQL.connect(PGHOST, :dbname => PGDB )
 
 # Now load OpenSSL, which might be linked against a different libssl.
 require 'socket'

--- a/sample/array_insert.rb
+++ b/sample/array_insert.rb
@@ -1,15 +1,15 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 
-c = PG.connect( dbname: 'test' )
+c = YugabyteYSQL.connect(dbname: 'test' )
 
 # this one works:
 c.exec( "DROP TABLE IF EXISTS foo" )
 c.exec( "CREATE TABLE foo (strings character varying[]);" )
 
 # But using a prepared statement works:
-c.set_error_verbosity( PG::PQERRORS_VERBOSE )
+c.set_error_verbosity(YugabyteYSQL::PQERRORS_VERBOSE )
 c.prepare( 'stmt', "INSERT INTO foo VALUES ($1);" )
 
 # This won't work

--- a/sample/async_copyto.rb
+++ b/sample/async_copyto.rb
@@ -1,12 +1,12 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 require 'stringio'
 
 # Using COPY asynchronously
 
 $stderr.puts "Opening database connection ..."
-conn = PG.connect( :dbname => 'test' )
+conn = YugabyteYSQL.connect(:dbname => 'test' )
 conn.setnonblocking( true )
 
 socket = conn.socket_io

--- a/sample/async_mixed.rb
+++ b/sample/async_mixed.rb
@@ -1,6 +1,6 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 
 $stdout.sync = true
 
@@ -21,9 +21,9 @@ end
 
 # Start the (synchronous) connection
 output_progress "Starting connection..."
-conn = PG.connect( CONN_OPTS ) or abort "Unable to create a new connection!"
+conn = YugabyteYSQL.connect(CONN_OPTS ) or abort "Unable to create a new connection!"
 
-abort "Connect failed: %s" % [ conn.error_message ] unless conn.status == PG::CONNECTION_OK
+abort "Connect failed: %s" % [ conn.error_message ] unless conn.status == YugabyteYSQL::CONNECTION_OK
 
 # Now grab a reference to the underlying socket to select() on while the query is running
 socket = conn.socket_io

--- a/sample/check_conn.rb
+++ b/sample/check_conn.rb
@@ -2,7 +2,7 @@
 # vim: set nosta noet ts=4 sw=4:
 # encoding: utf-8
 
-require 'pg'
+require 'yugabyte_ysql'
 
 # This is a minimal example of a function that can test an existing PG::Connection and
 # reset it if necessary.
@@ -10,12 +10,12 @@ require 'pg'
 def check_connection( conn )
 	begin
 		conn.exec( "SELECT 1" )
-	rescue PG::Error => err
+	rescue YugabyteYSQL::Error => err
 		$stderr.puts "%p while testing connection: %s" % [ err.class, err.message ]
 		conn.reset
 	end
 end
 
-conn = PG.connect( dbname: 'test' )
+conn = YugabyteYSQL.connect(dbname: 'test' )
 check_connection( conn )
 

--- a/sample/copydata.rb
+++ b/sample/copydata.rb
@@ -1,10 +1,10 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 require 'stringio'
 
 $stderr.puts "Opening database connection ..."
-conn = PG.connect( dbname: 'test' )
+conn = YugabyteYSQL.connect(dbname: 'test' )
 
 conn.exec( <<END_SQL )
 DROP TABLE IF EXISTS logs;

--- a/sample/copyfrom.rb
+++ b/sample/copyfrom.rb
@@ -1,10 +1,10 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 require 'stringio'
 
 $stderr.puts "Opening database connection ..."
-conn = PG.connect( :dbname => 'test' )
+conn = YugabyteYSQL.connect(:dbname => 'test' )
 
 conn.exec( <<END_SQL )
 DROP TABLE IF EXISTS logs;

--- a/sample/copyto.rb
+++ b/sample/copyto.rb
@@ -1,12 +1,12 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 require 'stringio'
 
 # An example of how to stream data to your local host from the database as CSV.
 
 $stderr.puts "Opening database connection ..."
-conn = PG.connect( :dbname => 'test' )
+conn = YugabyteYSQL.connect(:dbname => 'test' )
 
 $stderr.puts "Running COPY command ..."
 buf = ''

--- a/sample/cursor.rb
+++ b/sample/cursor.rb
@@ -1,12 +1,12 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 
 # An example of how to use SQL cursors. This is mostly a straight port of
 # the cursor portion of testlibpq.c from src/test/examples.
 
 $stderr.puts "Opening database connection ..."
-conn = PG.connect( :dbname => 'test' )
+conn = YugabyteYSQL.connect(:dbname => 'test' )
 
 #
 conn.transaction do

--- a/sample/disk_usage_report.rb
+++ b/sample/disk_usage_report.rb
@@ -13,7 +13,7 @@
 require 'ostruct'
 require 'optparse'
 require 'etc'
-require 'pg'
+require 'yugabyte_ysql'
 
 SCRIPT_VERSION = %q$Id$
 
@@ -21,7 +21,7 @@ SCRIPT_VERSION = %q$Id$
 ### Gather data and output it to $stdout.
 ###
 def report( opts )
-	db = PG.connect(
+	db = YugabyteYSQL.connect(
 		:dbname   => opts.database,
 		:host     => opts.host,
 		:port     => opts.port,

--- a/sample/issue-119.rb
+++ b/sample/issue-119.rb
@@ -1,6 +1,6 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 
 # This is another example of how to use COPY FROM, this time as a
 # minimal test case used to try to figure out what was going on in
@@ -9,14 +9,14 @@ require 'pg'
 #  https://bitbucket.org/ged/ruby-pg/issue/119
 #
 
-conn		   = PG.connect( dbname: 'test' )
+conn		   = YugabyteYSQL.connect(dbname: 'test' )
 table_name	   = 'issue_119'
 field_list	   = %w[name body_weight brain_weight]
 method		   = 0
 options		   = { truncate: true }
 sql_parameters = ''
 
-conn.set_error_verbosity( PG::PQERRORS_VERBOSE )
+conn.set_error_verbosity(YugabyteYSQL::PQERRORS_VERBOSE )
 conn.exec( "DROP TABLE IF EXISTS #{table_name}" )
 conn.exec( "CREATE TABLE #{table_name} ( id SERIAL, name TEXT, body_weight REAL, brain_weight REAL )" )
 
@@ -79,7 +79,7 @@ END_DATA
 		while res = rc.get_result
 			st = res.res_status( res.result_status )
 			puts "Result of COPY is: %s" % [ st ]
-			if res.result_status != PG::PGRES_COPY_IN
+			if res.result_status != YugabyteYSQL::PGRES_COPY_IN
 				puts res.error_message
 			end
 		end

--- a/sample/losample.rb
+++ b/sample/losample.rb
@@ -1,11 +1,11 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 
 SAMPLE_WRITE_DATA = 'some sample data'
 SAMPLE_EXPORT_NAME = 'lowrite.txt'
 
-conn = PG.connect( :dbname => 'test', :host => 'localhost', :port => 5432 )
+conn = YugabyteYSQL.connect(:dbname => 'test', :host => 'localhost', :port => 5432 )
 puts "dbname: " + conn.db + "\thost: " + conn.host + "\tuser: " + conn.user
 
 # Start a transaction, as all large object functions require one.
@@ -20,15 +20,15 @@ puts "  imported as large object %d" % [ oid ]
 
 # Read back 50 bytes of the imported data
 puts "Read test:"
-fd = conn.lo_open( oid, PG::INV_READ|PG::INV_WRITE )
-conn.lo_lseek( fd, 0, PG::SEEK_SET )
+fd = conn.lo_open(oid, YugabyteYSQL::INV_READ|YugabyteYSQL::INV_WRITE )
+conn.lo_lseek(fd, 0, YugabyteYSQL::SEEK_SET )
 buf = conn.lo_read( fd, 50 )
 puts "  read: %p" % [ buf ]
 puts "  read was ok!" if buf =~ /require 'pg'/
 
 # Append some test data onto the end of the object
 puts "Write test:"
-conn.lo_lseek( fd, 0, PG::SEEK_END )
+conn.lo_lseek(fd, 0, YugabyteYSQL::SEEK_END )
 buf = SAMPLE_WRITE_DATA.dup
 totalbytes = 0
 until buf.empty?
@@ -53,9 +53,9 @@ puts 'Testing read and delete from a new transaction:'
 puts '  starting a new transaction'
 conn.exec( 'BEGIN' )
 
-fd = conn.lo_open( oid, PG::INV_READ )
+fd = conn.lo_open(oid, YugabyteYSQL::INV_READ )
 puts '  reopened okay.'
-conn.lo_lseek( fd, 50, PG::SEEK_END )
+conn.lo_lseek(fd, 50, YugabyteYSQL::SEEK_END )
 buf = conn.lo_read( fd, 50 )
 puts '  read okay.' if buf == SAMPLE_WRITE_DATA
 

--- a/sample/minimal-testcase.rb
+++ b/sample/minimal-testcase.rb
@@ -1,14 +1,14 @@
 # -*- ruby -*-
 
-require 'pg'
+require 'yugabyte_ysql'
 
-conn = PG.connect( :dbname => 'test' )
+conn = YugabyteYSQL.connect(:dbname => 'test' )
 $stderr.puts '---',
-	RUBY_DESCRIPTION,
-	PG.version_string( true ),
-	"Server version: #{conn.server_version}",
-	"Client version: #{PG.library_version}",
-	'---'
+             RUBY_DESCRIPTION,
+             YugabyteYSQL.version_string(true ),
+             "Server version: #{conn.server_version}",
+             "Client version: #{YugabyteYSQL.library_version}",
+             '---'
 
 result = conn.exec( "SELECT * from pg_stat_activity" )
 

--- a/sample/notify_wait.rb
+++ b/sample/notify_wait.rb
@@ -10,7 +10,7 @@ BEGIN {
         $LOAD_PATH.unshift( libdir.to_s ) unless $LOAD_PATH.include?( libdir.to_s )
 }
 
-require 'pg'
+require 'yugabyte_ysql'
 
 TRIGGER_TABLE = %{
 	CREATE TABLE IF NOT EXISTS test ( message text );
@@ -41,7 +41,7 @@ FOR EACH STATEMENT
 EXECUTE PROCEDURE notify_test();
 }
 
-conn = PG.connect( :dbname => 'test' )
+conn = YugabyteYSQL.connect(:dbname => 'test' )
 
 conn.exec( TRIGGER_TABLE )
 conn.exec( TRIGGER_FUNCTION )

--- a/sample/pg_statistics.rb
+++ b/sample/pg_statistics.rb
@@ -16,7 +16,7 @@
 require 'ostruct'
 require 'optparse'
 require 'etc'
-require 'pg'
+require 'yugabyte_ysql'
 
 
 ### PostgreSQL Stats.  Fetch information from pg_stat_* tables.
@@ -27,7 +27,7 @@ class Stats
 
 	def initialize( opts )
 		@opts = opts
-		@db   = PG.connect(
+		@db   = YugabyteYSQL.connect(
 			:dbname   => opts.database,
 			:host     => opts.host,
 			:port     => opts.port,

--- a/sample/replication_monitor.rb
+++ b/sample/replication_monitor.rb
@@ -19,7 +19,7 @@ require 'ostruct'
 require 'optparse'
 require 'pathname'
 require 'etc'
-require 'pg'
+require 'yugabyte_ysql'
 require 'pp'
 
 
@@ -58,7 +58,7 @@ class PGMonitor
 		# check all slaves
 		self.slaves.each do |slave|
 			begin
-				slave_db = PG.connect(
+				slave_db = YugabyteYSQL.connect(
 					:dbname   => self.opts.database,
 					:host     => slave,
 					:port     => self.opts.port,
@@ -91,7 +91,7 @@ class PGMonitor
 	### the failures array and returns false.
 	###
 	def get_current_wal
-		master_db = PG.connect(
+		master_db = YugabyteYSQL.connect(
 			:dbname   => self.opts.database,
 			:host     => self.master,
 			:port     => self.opts.port,

--- a/sample/test_binary_values.rb
+++ b/sample/test_binary_values.rb
@@ -1,8 +1,8 @@
 # -*- ruby -*-1.9.1
 
-require 'pg'
+require 'yugabyte_ysql'
 
-db = PG.connect( :dbname => 'test' )
+db = YugabyteYSQL.connect(:dbname => 'test' )
 db.exec "DROP TABLE IF EXISTS test"
 db.exec "CREATE TABLE test (a INTEGER, b BYTEA)"
 

--- a/sample/warehouse_partitions.rb
+++ b/sample/warehouse_partitions.rb
@@ -41,7 +41,7 @@ require 'ostruct'
 require 'optparse'
 require 'pathname'
 require 'etc'
-require 'pg'
+require 'yugabyte_ysql'
 
 
 ### A tablespace migration class.
@@ -50,7 +50,7 @@ class PGWarehouse
 
 	def initialize( opts )
 		@opts = opts
-		@db = PG.connect(
+		@db = YugabyteYSQL.connect(
 			:dbname   => opts.database,
 			:host     => opts.host,
 			:port     => opts.port,

--- a/spec/pg/basic_type_map_for_results_spec.rb
+++ b/spec/pg/basic_type_map_for_results_spec.rb
@@ -6,21 +6,21 @@ require_relative '../helpers'
 require 'time'
 
 describe 'Basic type mapping' do
-	describe PG::BasicTypeMapForResults do
+	describe YugabyteYSQL::BasicTypeMapForResults do
 		let!(:basic_type_mapping) do
-			PG::BasicTypeMapForResults.new(@conn).freeze
+			YugabyteYSQL::BasicTypeMapForResults.new(@conn).freeze
 		end
 
 		it "can be initialized with a CoderMapsBundle instead of a connection" do
-			maps = PG::BasicTypeRegistry::CoderMapsBundle.new(@conn).freeze
-			tm = PG::BasicTypeMapForResults.new(maps)
-			expect( tm.rm_coder(0, 16) ).to be_kind_of(PG::TextDecoder::Boolean)
+			maps = YugabyteYSQL::BasicTypeRegistry::CoderMapsBundle.new(@conn).freeze
+			tm = YugabyteYSQL::BasicTypeMapForResults.new(maps)
+			expect( tm.rm_coder(0, 16) ).to be_kind_of(YugabyteYSQL::TextDecoder::Boolean)
 		end
 
 		it "can be initialized with a custom type registry" do
-			regi = PG::BasicTypeRegistry.new
-			regi.register_type 1, 'int4', nil, PG::BinaryDecoder::Integer
-			tm = PG::BasicTypeMapForResults.new(@conn, registry: regi).freeze
+			regi = YugabyteYSQL::BasicTypeRegistry.new
+			regi.register_type 1, 'int4', nil, YugabyteYSQL::BinaryDecoder::Integer
+			tm = YugabyteYSQL::BasicTypeMapForResults.new(@conn, registry: regi).freeze
 			res = @conn.exec_params( "SELECT '2021-08-03'::DATE, 234", [], 1 ).map_types!(tm)
 			expect{ res.values }.to output(/no type cast defined for type "date" format 1 /).to_stderr
 			expect( res.values ).to eq( [["\x00\x00\x1E\xCD".b, 234]] )
@@ -32,7 +32,7 @@ describe 'Basic type mapping' do
 
 		it "should be usable with Ractor and shared type map", :ractor do
 			vals = Ractor.new(@conninfo, Ractor.make_shareable(basic_type_mapping)) do |conninfo, btm|
-				conn = PG.connect(conninfo)
+				conn = YugabyteYSQL.connect(conninfo)
 				res = conn.exec( "SELECT 1, 'a', 2.0::FLOAT, TRUE, '2013-06-30'::DATE" )
 				res.map_types!(btm).values
 			ensure
@@ -46,9 +46,9 @@ describe 'Basic type mapping' do
 
 		it "should be usable with Ractor", :ractor do
 			vals = Ractor.new(@conninfo) do |conninfo|
-				conn = PG.connect(conninfo)
+				conn = YugabyteYSQL.connect(conninfo)
 				res = conn.exec( "SELECT 1, 'a', 2.0::FLOAT, TRUE, '2013-06-30'::DATE" )
-				btm = PG::BasicTypeMapForResults.new(conn)
+				btm = YugabyteYSQL::BasicTypeMapForResults.new(conn)
 				res.map_types!(btm).values
 			ensure
 				conn&.finish
@@ -73,8 +73,8 @@ describe 'Basic type mapping' do
 
 		[1, 0].each do |format|
 			it "should warn about undefined types in format #{format}" do
-				regi = PG::BasicTypeRegistry.new.freeze
-				tm = PG::BasicTypeMapForResults.new(@conn, registry: regi).freeze
+				regi = YugabyteYSQL::BasicTypeRegistry.new.freeze
+				tm = YugabyteYSQL::BasicTypeMapForResults.new(@conn, registry: regi).freeze
 				res = @conn.exec_params( "SELECT 1.23", [], format ).map_types!(tm)
 				expect{ res.values }.to output(/type "numeric".*format #{format}.*oid 1700/).to_stderr
 			end
@@ -90,7 +90,7 @@ describe 'Basic type mapping' do
 			end
 
 			after :each do
-				@conn.type_map_for_results = PG::TypeMapAllStrings.new.freeze
+				@conn.type_map_for_results = YugabyteYSQL::TypeMapAllStrings.new.freeze
 			end
 
 			it "should do boolean type conversions" do
@@ -163,9 +163,9 @@ describe 'Basic type mapping' do
 
 			[1, 0].each do |format|
 				it "should convert format #{format} timestamps per TimestampUtc" do
-					regi = PG::BasicTypeRegistry.new.register_default_types
-					regi.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampUtc
-					@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn, registry: regi)
+					regi = YugabyteYSQL::BasicTypeRegistry.new.register_default_types
+					regi.register_type 0, 'timestamp', nil, YugabyteYSQL::TextDecoder::TimestampUtc
+					@conn.type_map_for_results = YugabyteYSQL::BasicTypeMapForResults.new(@conn, registry: regi)
 					res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('1913-12-31 23:58:59.1231-03' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -183,10 +183,10 @@ describe 'Basic type mapping' do
 
 			[1, 0].each do |format|
 				it "should convert format #{format} timestamps per TimestampUtcToLocal" do
-					regi = PG::BasicTypeRegistry.new
-					regi.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampUtcToLocal
-					regi.register_type 1, 'timestamp', nil, PG::BinaryDecoder::TimestampUtcToLocal
-					@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn, registry: regi)
+					regi = YugabyteYSQL::BasicTypeRegistry.new
+					regi.register_type 0, 'timestamp', nil, YugabyteYSQL::TextDecoder::TimestampUtcToLocal
+					regi.register_type 1, 'timestamp', nil, YugabyteYSQL::BinaryDecoder::TimestampUtcToLocal
+					@conn.type_map_for_results = YugabyteYSQL::BasicTypeMapForResults.new(@conn, registry: regi)
 					res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('1913-12-31 23:58:59.1231-03' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -204,10 +204,10 @@ describe 'Basic type mapping' do
 
 			[1, 0].each do |format|
 				it "should convert format #{format} timestamps per TimestampLocal" do
-					regi = PG::BasicTypeRegistry.new
-					regi.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampLocal
-					regi.register_type 1, 'timestamp', nil, PG::BinaryDecoder::TimestampLocal
-					@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn, registry: regi)
+					regi = YugabyteYSQL::BasicTypeRegistry.new
+					regi.register_type 0, 'timestamp', nil, YugabyteYSQL::TextDecoder::TimestampLocal
+					regi.register_type 1, 'timestamp', nil, YugabyteYSQL::BinaryDecoder::TimestampLocal
+					@conn.type_map_for_results = YugabyteYSQL::BasicTypeMapForResults.new(@conn, registry: regi)
 					res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('1913-12-31 23:58:59.1231' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -394,7 +394,7 @@ describe 'Basic type mapping' do
 				# Retrieve table OIDs per empty result.
 				res = @conn.exec( "SELECT * FROM copytable LIMIT 0" )
 				tm = basic_type_mapping.build_column_map( res )
-				row_decoder = PG::TextDecoder::CopyRow.new(type_map: tm).freeze
+				row_decoder = YugabyteYSQL::TextDecoder::CopyRow.new(type_map: tm).freeze
 
 				rows = []
 				@conn.copy_data( "COPY copytable TO STDOUT", row_decoder ) do |res|
@@ -412,7 +412,7 @@ describe 'Basic type mapping' do
 				# Retrieve table OIDs per empty result.
 				res = @conn.exec_params( "SELECT * FROM copytable LIMIT 0", [], 1 )
 				tm = basic_type_mapping.build_column_map( res )
-				row_decoder = PG::BinaryDecoder::CopyRow.new(type_map: tm).freeze
+				row_decoder = YugabyteYSQL::BinaryDecoder::CopyRow.new(type_map: tm).freeze
 
 				rows = []
 				@conn.copy_data( "COPY copytable TO STDOUT WITH (FORMAT binary)", row_decoder ) do |res|

--- a/spec/pg/basic_type_registry_spec.rb
+++ b/spec/pg/basic_type_registry_spec.rb
@@ -4,51 +4,51 @@
 require_relative '../helpers'
 
 describe 'Basic type mapping' do
-	describe PG::BasicTypeRegistry do
+	describe YugabyteYSQL::BasicTypeRegistry do
 		it "should be shareable for Ractor", :ractor do
-			Ractor.make_shareable(PG::BasicTypeRegistry.new.register_default_types)
+			Ractor.make_shareable(YugabyteYSQL::BasicTypeRegistry.new.register_default_types)
 		end
 
 		it "can register_type" do
-			regi = PG::BasicTypeRegistry.new
-			res = regi.register_type(1, 'int4', PG::BinaryEncoder::Int8, PG::BinaryDecoder::Integer)
+			regi = YugabyteYSQL::BasicTypeRegistry.new
+			res = regi.register_type(1, 'int4', YugabyteYSQL::BinaryEncoder::Int8, YugabyteYSQL::BinaryDecoder::Integer)
 
 			expect( res ).to be( regi )
-			expect( regi.coders_for(1, :encoder)['int4'] ).to be_kind_of(PG::BinaryEncoder::Int8)
-			expect( regi.coders_for(1, :decoder)['int4'] ).to be_kind_of(PG::BinaryDecoder::Integer)
+			expect( regi.coders_for(1, :encoder)['int4'] ).to be_kind_of(YugabyteYSQL::BinaryEncoder::Int8)
+			expect( regi.coders_for(1, :decoder)['int4'] ).to be_kind_of(YugabyteYSQL::BinaryDecoder::Integer)
 		end
 
 		it "can alias_type" do
-			regi = PG::BasicTypeRegistry.new
-			regi.register_type(1, 'int4', PG::BinaryEncoder::Int4, PG::BinaryDecoder::Integer)
+			regi = YugabyteYSQL::BasicTypeRegistry.new
+			regi.register_type(1, 'int4', YugabyteYSQL::BinaryEncoder::Int4, YugabyteYSQL::BinaryDecoder::Integer)
 			res = regi.alias_type(1, 'int8', 'int4')
 
 			expect( res ).to be( regi )
-			expect( regi.coders_for(1, :encoder)['int8'] ).to be_kind_of(PG::BinaryEncoder::Int4)
-			expect( regi.coders_for(1, :decoder)['int8'] ).to be_kind_of(PG::BinaryDecoder::Integer)
+			expect( regi.coders_for(1, :encoder)['int8'] ).to be_kind_of(YugabyteYSQL::BinaryEncoder::Int4)
+			expect( regi.coders_for(1, :decoder)['int8'] ).to be_kind_of(YugabyteYSQL::BinaryDecoder::Integer)
 		end
 
 		it "can register_default_types" do
-			regi = PG::BasicTypeRegistry.new
+			regi = YugabyteYSQL::BasicTypeRegistry.new
 			res = regi.register_default_types
 
 			expect( res ).to be( regi )
-			expect( regi.coders_for(0, :encoder)['float8'] ).to be_kind_of(PG::TextEncoder::Float)
-			expect( regi.coders_for(0, :decoder)['float8'] ).to be_kind_of(PG::TextDecoder::Float)
+			expect( regi.coders_for(0, :encoder)['float8'] ).to be_kind_of(YugabyteYSQL::TextEncoder::Float)
+			expect( regi.coders_for(0, :decoder)['float8'] ).to be_kind_of(YugabyteYSQL::TextDecoder::Float)
 		end
 
 		it "can define_default_types (alias to register_default_types)" do
-			regi = PG::BasicTypeRegistry.new
+			regi = YugabyteYSQL::BasicTypeRegistry.new
 			res = regi.define_default_types
 
 			expect( res ).to be( regi )
-			expect( regi.coders_for(0, :encoder)['float8'] ).to be_kind_of(PG::TextEncoder::Float)
-			expect( regi.coders_for(0, :decoder)['float8'] ).to be_kind_of(PG::TextDecoder::Float)
+			expect( regi.coders_for(0, :encoder)['float8'] ).to be_kind_of(YugabyteYSQL::TextEncoder::Float)
+			expect( regi.coders_for(0, :decoder)['float8'] ).to be_kind_of(YugabyteYSQL::TextDecoder::Float)
 		end
 
 		it "can register_coder" do
-			regi = PG::BasicTypeRegistry.new
-			enco = PG::BinaryEncoder::Int8.new(name: 'test')
+			regi = YugabyteYSQL::BasicTypeRegistry.new
+			enco = YugabyteYSQL::BinaryEncoder::Int8.new(name: 'test')
 			res = regi.register_coder(enco)
 
 			expect( res ).to be( regi )
@@ -57,7 +57,7 @@ describe 'Basic type mapping' do
 		end
 
 		it "checks format and direction in coders_for" do
-			regi = PG::BasicTypeRegistry.new
+			regi = YugabyteYSQL::BasicTypeRegistry.new
 			expect( regi.coders_for 0, :encoder ).to eq( nil )
 			expect{ regi.coders_for 0, :coder }.to raise_error( ArgumentError )
 			expect{ regi.coders_for 2, :encoder }.to raise_error( ArgumentError )

--- a/spec/pg/connection_async_spec.rb
+++ b/spec/pg/connection_async_spec.rb
@@ -4,15 +4,15 @@
 require_relative '../helpers'
 
 require 'socket'
-require 'pg'
+require 'yugabyte_ysql'
 
-describe PG::Connection do
+describe YugabyteYSQL::Connection do
 
 	it "tries to connect to localhost with IPv6 and IPv4", :ipv6, :postgresql_10 do
 		uri = "postgres://localhost:#{@port+1}/test"
 		expect(described_class).to receive(:parse_connect_args).once.ordered.with(uri, any_args).and_call_original
 		expect(described_class).to receive(:parse_connect_args).once.ordered.with(hash_including(hostaddr: "::1,127.0.0.1")).and_call_original
-		expect{ described_class.connect( uri ) }.to raise_error(PG::ConnectionBad)
+		expect{ described_class.connect( uri ) }.to raise_error(YugabyteYSQL::ConnectionBad)
 	end
 
 	def interrupt_thread(exc=nil)
@@ -66,7 +66,7 @@ describe PG::Connection do
 				end
 			end
 
-			expect( t.value ).to be_kind_of( PG::UndefinedColumn )
+			expect( t.value ).to be_kind_of(YugabyteYSQL::UndefinedColumn )
 			expect( duration ).to be < 10
 		end
 
@@ -88,8 +88,8 @@ describe PG::Connection do
 				end
 			end
 
-			expect( t.value ).to be_kind_of( PG::Result )
-			expect( t.value.result_status ).to eq( PG::PGRES_COMMAND_OK )
+			expect( t.value ).to be_kind_of(YugabyteYSQL::Result )
+			expect( t.value.result_status ).to eq(YugabyteYSQL::PGRES_COMMAND_OK )
 		end
 	end
 
@@ -125,7 +125,7 @@ describe PG::Connection do
 				serv = TCPServer.new( '127.0.0.1', 54320 )
 				expect {
 					described_class.connect( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
-				}.to raise_error(PG::ConnectionBad, /server closed the connection unexpectedly/)
+				}.to raise_error(YugabyteYSQL::ConnectionBad, /server closed the connection unexpectedly/)
 			end
 
 			sleep 0.5

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -5,20 +5,20 @@ require_relative '../helpers'
 
 require 'timeout'
 require 'socket'
-require 'pg'
+require 'yugabyte_ysql'
 
 # Work around ruby bug: https://bugs.ruby-lang.org/issues/19562
 ''.encode(Encoding::ISO8859_2)
 ''.encode(Encoding::KOI8_R)
 
-describe PG::Connection do
+describe YugabyteYSQL::Connection do
 
 	it "should give account about memory usage" do
 		expect( ObjectSpace.memsize_of(@conn) ).to be > DATA_OBJ_MEMSIZE
 	end
 
 	it "should deny changes when frozen" do
-		c = PG.connect(@conninfo).freeze
+		c = YugabyteYSQL.connect(@conninfo).freeze
 		expect{ c.setnonblocking true }.to raise_error(FrozenError)
 		expect{ c.field_name_type = :symbol  }.to raise_error(FrozenError)
 		expect{ c.set_default_encoding }.to raise_error(FrozenError)
@@ -28,7 +28,7 @@ describe PG::Connection do
 	end
 
 	it "shouldn't be shareable for Ractor", :ractor do
-		c = PG.connect(@conninfo)
+		c = YugabyteYSQL.connect(@conninfo)
 		expect{ Ractor.make_shareable(c) }.to raise_error(Ractor::Error, /PG::Connection/)
 	ensure
 		c&.finish
@@ -36,7 +36,7 @@ describe PG::Connection do
 
 	it "should be usable with Ractor", :ractor do
 		vals = Ractor.new(@conninfo) do |conninfo|
-			conn = PG.connect(conninfo)
+			conn = YugabyteYSQL.connect(conninfo)
 			conn.setnonblocking true
 			conn.setnonblocking false
 			conn.exec("SELECT 123").values
@@ -53,13 +53,13 @@ describe PG::Connection do
 		end
 
 		it "should tell about finished connection" do
-			conn = PG.connect(@conninfo)
+			conn = YugabyteYSQL.connect(@conninfo)
 			conn.finish
 			expect( conn.inspect ).to match(/<PG::Connection:[0-9a-fx]+ finished>/)
 		end
 
 		it "should tell about connection status" do
-			conn = PG::Connection.connect_start(@conninfo)
+			conn = YugabyteYSQL::Connection.connect_start(@conninfo)
 			expect( conn.inspect ).to match(/ status=CONNECTION_STARTED/)
 		end
 
@@ -84,22 +84,22 @@ describe PG::Connection do
 		end
 
 		it "should tell about non default type_map_for_results" do
-			@conn.type_map_for_results = PG::TypeMapByColumn.new([])
+			@conn.type_map_for_results = YugabyteYSQL::TypeMapByColumn.new([])
 			expect( @conn.inspect ).to match(/ type_map_for_results=#<PG::TypeMapByColumn:[0-9a-fx]+>/)
 		end
 
 		it "should tell about non default type_map_for_queries" do
-			@conn.type_map_for_queries = PG::TypeMapByColumn.new([])
+			@conn.type_map_for_queries = YugabyteYSQL::TypeMapByColumn.new([])
 			expect( @conn.inspect ).to match(/ type_map_for_queries=#<PG::TypeMapByColumn:[0-9a-fx]+>/)
 		end
 
 		it "should tell about encoder_for_put_copy_data" do
-			@conn.encoder_for_put_copy_data = PG::TextEncoder::CopyRow.new
+			@conn.encoder_for_put_copy_data = YugabyteYSQL::TextEncoder::CopyRow.new
 			expect( @conn.inspect ).to match(/ encoder_for_put_copy_data=#<PG::TextEncoder::CopyRow:[0-9a-fx]+>/)
 		end
 
 		it "should tell about decoder_for_get_copy_data" do
-			@conn.decoder_for_get_copy_data = PG::TextDecoder::CopyRow.new
+			@conn.decoder_for_get_copy_data = YugabyteYSQL::TextDecoder::CopyRow.new
 			expect( @conn.inspect ).to match(/ decoder_for_get_copy_data=#<PG::TextDecoder::CopyRow:[0-9a-fx]+>/)
 		end
 	end
@@ -130,7 +130,7 @@ describe PG::Connection do
 		end
 
 		it "can parse connection info strings kind of key=value" do
-			ar = PG::Connection.conninfo_parse("user=auser  host=somehost  port=3334 dbname=db")
+			ar = YugabyteYSQL::Connection.conninfo_parse("user=auser  host=somehost  port=3334 dbname=db")
 			expect( ar ).to be_kind_of( Array )
 			expect( ar.first ).to be_kind_of( Hash )
 			expect( ar.map{|a| a[:keyword] } ).to include( "dbname", "user", "password", "port" )
@@ -138,7 +138,7 @@ describe PG::Connection do
 		end
 
 		it "can parse connection info strings kind of URI" do
-			ar = PG::Connection.conninfo_parse("postgresql://auser@somehost:3334/db")
+			ar = YugabyteYSQL::Connection.conninfo_parse("postgresql://auser@somehost:3334/db")
 			expect( ar ).to be_kind_of( Array )
 			expect( ar.first ).to be_kind_of( Hash )
 			expect( ar.map{|a| a[:keyword] } ).to include( "dbname", "user", "password", "port" )
@@ -146,8 +146,8 @@ describe PG::Connection do
 		end
 
 		it "can parse connection info strings with error" do
-			expect{ PG::Connection.conninfo_parse("host='abc") }.to raise_error(PG::Error, /unterminated quoted string/)
-			expect{ PG::Connection.conninfo_parse("host") }.to raise_error(PG::Error, /missing "=" after/)
+			expect{ YugabyteYSQL::Connection.conninfo_parse("host='abc") }.to raise_error(YugabyteYSQL::Error, /unterminated quoted string/)
+			expect{ YugabyteYSQL::Connection.conninfo_parse("host") }.to raise_error(YugabyteYSQL::Error, /missing "=" after/)
 		end
 	end
 
@@ -278,7 +278,7 @@ describe PG::Connection do
 		end
 
 		it "sets the fallback_application_name on new connections" do
-			conn_string = PG::Connection.parse_connect_args( 'dbname=test' )
+			conn_string = YugabyteYSQL::Connection.parse_connect_args('dbname=test' )
 
 			conn_name = conn_string[ /application_name='(.*?)'/, 1 ]
 			expect( conn_name ).to include( $0[0..10] )
@@ -287,30 +287,30 @@ describe PG::Connection do
 		end
 
 		it "sets a shortened fallback_application_name on new connections" do
-			old_script_name = PG::Connection.class_eval("PROGRAM_NAME")
+			old_script_name = YugabyteYSQL::Connection.class_eval("PROGRAM_NAME")
 			begin
 				prg = '/this/is/a/very/long/path/with/many/directories/to/our/beloved/ruby'
-				PG::Connection.class_eval("PROGRAM_NAME=#{prg.inspect}")
-				conn_string = PG::Connection.parse_connect_args( 'dbname=test' )
+				YugabyteYSQL::Connection.class_eval("PROGRAM_NAME=#{prg.inspect}")
+				conn_string = YugabyteYSQL::Connection.parse_connect_args('dbname=test' )
 				conn_name = conn_string[ /application_name='(.*?)'/, 1 ]
 				expect( conn_name ).to include( prg[0..10] )
 				expect( conn_name ).to include( prg[-10..-1] )
 				expect( conn_name.length ).to be <= 64
 			ensure
-				PG::Connection.class_eval("PROGRAM_NAME=PG.make_shareable(#{old_script_name.inspect})")
+				YugabyteYSQL::Connection.class_eval("PROGRAM_NAME=PG.make_shareable(#{old_script_name.inspect})")
 			end
 		end
 	end
 
 	it "connects successfully with connection string" do
 		tmpconn = described_class.connect( @conninfo )
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		tmpconn.finish
 	end
 
 	it "connects using 7 arguments converted to strings" do
 		tmpconn = described_class.connect( 'localhost', @port, nil, nil, :test, nil, nil )
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		tmpconn.finish
 	end
 
@@ -319,7 +319,7 @@ describe PG::Connection do
 			:host => 'localhost',
 			:port => @port,
 			:dbname => :test)
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		tmpconn.finish
 	end
 
@@ -329,7 +329,7 @@ describe PG::Connection do
 			:port => @port,
 			:dbname => :test,
 			:keepalives => 1)
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		tmpconn.finish
 	end
 
@@ -353,7 +353,7 @@ describe PG::Connection do
 		                              :port => @port,
 		                              :dbname => "non-existent")
 				}.to raise_error do |error|
-			expect( error ).to be_an( PG::ConnectionBad )
+			expect( error ).to be_an(YugabyteYSQL::ConnectionBad )
 			expect( error.message ).to match( /database "non-existent" does not exist/i )
 			expect( error.message.encoding ).to eq( Encoding::BINARY )
 		end
@@ -369,9 +369,9 @@ describe PG::Connection do
 																connect_timeout: 1,
 																dbname: "test")
 			}.to raise_error do |error|
-				expect( error ).to be_an( PG::ConnectionBad )
+				expect( error ).to be_an(YugabyteYSQL::ConnectionBad )
 				expect( error.message ).to match( /timeout expired/ )
-				if PG.library_version >= 120000
+				if YugabyteYSQL.library_version >= 120000
 					expect( error.message ).to match( /\"localhost\"/ )
 					expect( error.message ).to match( /port 54320/ )
 				end
@@ -384,9 +384,9 @@ describe PG::Connection do
 	context "with multiple PostgreSQL servers", :without_transaction do
 		before :all do
 			@port_ro = @port + 1
-			@dbms = PG::TestingHelpers::PostgresServer.new("read-only",
-				port: @port_ro,
-				postgresql_conf: "default_transaction_read_only=on"
+			@dbms = YugabyteYSQL::TestingHelpers::PostgresServer.new("read-only",
+                                                               port: @port_ro,
+                                                               postgresql_conf: "default_transaction_read_only=on"
 			)
 		end
 
@@ -396,12 +396,12 @@ describe PG::Connection do
 
 		it "honors target_session_attrs requirements", :postgresql_10 do
 			uri = "postgres://localhost:#{@port_ro},localhost:#{@port}/postgres?target_session_attrs=read-write"
-			PG.connect(uri) do |conn|
+			YugabyteYSQL.connect(uri) do |conn|
 				expect( conn.port ).to eq( @port )
 			end
 
 			uri = "postgres://localhost:#{@port_ro},localhost:#{@port}/postgres?target_session_attrs=any"
-			PG.connect(uri) do |conn|
+			YugabyteYSQL.connect(uri) do |conn|
 				expect( conn.port ).to eq( @port_ro )
 			end
 		end
@@ -419,16 +419,16 @@ describe PG::Connection do
 		else
 			/authenti.*testusermd5/i
 		end
-		expect { PG.connect(uri) }.to raise_error(error_match)
+		expect { YugabyteYSQL.connect(uri) }.to raise_error(error_match)
 
 		uri = "host=::1,::1,127.0.0.1 port=#{@port_down},#{@port},#{@port} dbname=postgres user=testusermd5 password=secret"
-		PG.connect(uri) do |conn|
+		YugabyteYSQL.connect(uri) do |conn|
 			expect( conn.host ).to eq( "::1" )
 			expect( conn.port ).to eq( @port )
 		end
 
 		uri = "host=::1,::1,127.0.0.1 port=#{@port_down},#{@port_down},#{@port} dbname=postgres user=testusermd5 password=wrong"
-		PG.connect(uri) do |conn|
+		YugabyteYSQL.connect(uri) do |conn|
 			expect( conn.host ).to eq( "127.0.0.1" )
 			expect( conn.port ).to eq( @port )
 		end
@@ -437,7 +437,7 @@ describe PG::Connection do
 	it "connects using URI with multiple hosts", :postgresql_12 do
 		uri = "postgres://localhost:#{@port_down},127.0.0.1:#{@port}/test?keepalives=1"
 		tmpconn = described_class.connect( uri )
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		expect( tmpconn.port ).to eq( @port )
 		expect( tmpconn.host ).to eq( "127.0.0.1" )
 		expect( tmpconn.hostaddr ).to match( /\A(::1|127\.0\.0\.1)\z/ )
@@ -447,7 +447,7 @@ describe PG::Connection do
 	it "connects using URI with IPv6 hosts", :postgresql_12, :ipv6 do
 		uri = "postgres://localhost:#{@port},[::1]:#{@port},/test"
 		tmpconn = described_class.connect( uri )
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		expect( tmpconn.host ).to eq( "localhost" )
 		expect( tmpconn.hostaddr ).to match( /\A(::1|127\.0\.0\.1)\z/ )
 		tmpconn.finish
@@ -456,26 +456,26 @@ describe PG::Connection do
 	it "connects using URI with UnixSocket host", :postgresql_12, :unix_socket do
 		uri = "postgres://#{@unix_socket.gsub("/", "%2F")}:#{@port}/test"
 		tmpconn = described_class.connect( uri )
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		expect( tmpconn.host ).to eq( @unix_socket )
 		expect( tmpconn.hostaddr ).to eq( "" )
 		tmpconn.finish
 	end
 
 	it "connects with environment variables" do
-		skip("Is broken before postgresql-12 on Windows") if RUBY_PLATFORM=~/mingw|mswin/ && PG.library_version < 120000
+		skip("Is broken before postgresql-12 on Windows") if RUBY_PLATFORM=~/mingw|mswin/ && YugabyteYSQL.library_version < 120000
 
 		tmpconn = with_env_vars(PGHOST: "localhost", PGPORT: @port, PGDATABASE: "test") do
 			described_class.connect
 		end
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		expect( tmpconn.host ).to eq( "localhost" )
 		tmpconn.finish
 	end
 
 	it "connects using Hash with multiple hosts", :postgresql_12 do
 		tmpconn = described_class.connect( host: "#{@unix_socket}xx,127.0.0.1,localhost", port: @port, dbname: "test" )
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		expect( tmpconn.host ).to eq( "127.0.0.1" )
 		expect( tmpconn.hostaddr ).to match( /\A127\.0\.0\.1\z/ )
 		tmpconn.finish
@@ -488,7 +488,7 @@ describe PG::Connection do
 			end
 			klass.send(meth, @conninfo) do |conn|
 				expect( conn ).to be_a_kind_of( klass )
-				expect( conn.execute("SELECT 1") ).to be_a_kind_of( PG::Result )
+				expect( conn.execute("SELECT 1") ).to be_a_kind_of(YugabyteYSQL::Result )
 			end
 		end
 	end
@@ -498,7 +498,7 @@ describe PG::Connection do
 		expect( tmpconn ).to be_a( described_class )
 
 		wait_for_polling_ok(tmpconn)
-		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+		expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		tmpconn.finish
 	end
 
@@ -510,7 +510,7 @@ describe PG::Connection do
 			conn = tmpconn
 
 			wait_for_polling_ok(tmpconn)
-			expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+			expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 		end
 
 		expect( conn ).to be_finished()
@@ -567,7 +567,7 @@ describe PG::Connection do
 			# Connect with SSL, but use a wrong client cert, so that connection is aborted.
 			# A second connection is then started with a new IO.
 			# And since the pipes above were freed in the concurrent thread above, there is a high chance that it's a lower file descriptor than before.
-			conn = PG.connect( @conninfo + " sslcert=tmp_test_specs/data/ruby-pg-ca-cert" )
+			conn = YugabyteYSQL.connect(@conninfo + " sslcert=tmp_test_specs/data/ruby-pg-ca-cert" )
 			expect( conn.ssl_in_use? ).to be_falsey
 
 			# The new connection should work even when the file descriptor has changed.
@@ -644,7 +644,7 @@ describe PG::Connection do
 		end
 
 		it "sets nonblocking for the connection only" do
-			co2 = PG.connect(@conninfo)
+			co2 = YugabyteYSQL.connect(@conninfo)
 			expect( co2.setnonblocking(true) ).to be_nil
 			expect( co2.isnonblocking ).to eq(true)
 			expect( @conn.isnonblocking ).to eq(false)
@@ -745,13 +745,13 @@ describe PG::Connection do
 					while @conn.get_copy_data
 					end
 				end
-			end.to raise_error(PG::QueryCanceled){|err| expect(err).to have_attributes(connection: @conn) }
+			end.to raise_error(YugabyteYSQL::QueryCanceled){|err| expect(err).to have_attributes(connection: @conn) }
 		end
 	end
 
 	it "raises proper error when sending fails" do
 		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
-		expect{ conn.exec 'SELECT 1' }.to raise_error(PG::UnableToSend, /no connection/){|err| expect(err).to have_attributes(connection: conn) }
+		expect{ conn.exec 'SELECT 1' }.to raise_error(YugabyteYSQL::UnableToSend, /no connection/){|err| expect(err).to have_attributes(connection: conn) }
 	end
 
 	it "doesn't leave stale server connections after finish" do
@@ -778,19 +778,19 @@ describe PG::Connection do
 				external_host: 'localhost',
 				external_port: ENV['PGPORT'].to_i,
 				internal_host: "127.0.0.1",
-				internal_port: PG::DEF_PGPORT,
+				internal_port: YugabyteYSQL::DEF_PGPORT,
 				debug: ENV['PG_DEBUG']=='1')
 
-		PG.connect(host: "localhost",
-				port: "",
-				dbname: "test") do |conn|
-			expect( conn.port ).to eq( PG::DEF_PGPORT )
+		YugabyteYSQL.connect(host: "localhost",
+                         port: "",
+                         dbname: "test") do |conn|
+			expect( conn.port ).to eq(YugabyteYSQL::DEF_PGPORT )
 		end
 
-		PG.connect(hostaddr: "127.0.0.1",
-				port: nil,
-				dbname: "test") do |conn|
-			expect( conn.port ).to eq( PG::DEF_PGPORT )
+		YugabyteYSQL.connect(hostaddr: "127.0.0.1",
+                         port: nil,
+                         dbname: "test") do |conn|
+			expect( conn.port ).to eq(YugabyteYSQL::DEF_PGPORT )
 		end
 
 		gate.finish
@@ -803,15 +803,15 @@ describe PG::Connection do
 	end
 
 	it "can set error verbosity" do
-		old = @conn.set_error_verbosity( PG::PQERRORS_TERSE )
+		old = @conn.set_error_verbosity(YugabyteYSQL::PQERRORS_TERSE )
 		new = @conn.set_error_verbosity( old )
-		expect( new ).to eq( PG::PQERRORS_TERSE )
+		expect( new ).to eq(YugabyteYSQL::PQERRORS_TERSE )
 	end
 
 	it "can set error context visibility", :postgresql_96 do
-		old = @conn.set_error_context_visibility( PG::PQSHOW_CONTEXT_NEVER )
+		old = @conn.set_error_context_visibility(YugabyteYSQL::PQSHOW_CONTEXT_NEVER )
 		new = @conn.set_error_context_visibility( old )
-		expect( new ).to eq( PG::PQSHOW_CONTEXT_NEVER )
+		expect( new ).to eq(YugabyteYSQL::PQSHOW_CONTEXT_NEVER )
 	end
 
 	let(:expected_trace_output_pre_14) do
@@ -871,7 +871,7 @@ describe PG::Connection do
 
 		trace_data = trace_file.read
 
-		if PG.library_version >= 140000
+		if YugabyteYSQL.library_version >= 140000
 			trace_data.gsub!( /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}/, 'TIMESTAMP' )
 
 			expect( trace_data ).to eq( expected_trace_output )
@@ -894,7 +894,7 @@ describe PG::Connection do
 			@conn.cancel if notice =~ /foobar/
 		end
 		@conn.send_query "do $$ BEGIN RAISE NOTICE 'foobar'; PERFORM pg_sleep(10); END; $$ LANGUAGE plpgsql;"
-		expect{ @conn.get_last_result }.to raise_error(PG::QueryCanceled){|err| expect(err).to have_attributes(connection: @conn) }
+		expect{ @conn.get_last_result }.to raise_error(YugabyteYSQL::QueryCanceled){|err| expect(err).to have_attributes(connection: @conn) }
 		expect( Time.now - start ).to be < 9.9
 	end
 
@@ -933,7 +933,7 @@ describe PG::Connection do
 				end
 
 				# if the previous transaction committed, the result should be visible from another conn/transaction
-				@conn2 = PG.connect(@conninfo)
+				@conn2 = YugabyteYSQL.connect(@conninfo)
 				begin
 					res = @conn2.exec( "SELECT * FROM pie" )
 					expect( res.ntuples ).to eq( 3 )
@@ -962,10 +962,10 @@ describe PG::Connection do
 		it "not read past the end of a large object" do
 			@conn.transaction do
 				oid = @conn.lo_create( 0 )
-				fd = @conn.lo_open( oid, PG::INV_READ|PG::INV_WRITE )
+				fd = @conn.lo_open(oid, YugabyteYSQL::INV_READ|YugabyteYSQL::INV_WRITE )
 				expect( @conn.lo_write( fd, "foobar" ) ).to eq( 6 )
 				expect( @conn.lo_read( fd, 10 ) ).to be_nil()
-				expect( @conn.lo_lseek( fd, 0, PG::SEEK_SET ) ).to eq( 0 )
+				expect( @conn.lo_lseek(fd, 0, YugabyteYSQL::SEEK_SET ) ).to eq(0 )
 				expect( @conn.lo_read( fd, 10 ) ).to eq( 'foobar' )
 				expect( @conn.lo_close( fd ) ).to be_nil
 				expect( @conn.lo_unlink( oid ) ).to be_nil
@@ -984,13 +984,13 @@ describe PG::Connection do
 			bytes = Random.urandom(512000)
 			oid = conn.lo_creat
 			conn.transaction do
-				fd = conn.lo_open( oid, PG::INV_WRITE )
+				fd = conn.lo_open(oid, YugabyteYSQL::INV_WRITE )
 				conn.lo_write( fd, bytes )
 				expect( conn.lo_close( fd ) ).to be_nil
 			end
 
 			conn.transaction do
-				fd = conn.lo_open( oid, PG::INV_READ )
+				fd = conn.lo_open(oid, YugabyteYSQL::INV_READ )
 				bytes2 = conn.lo_read( fd, bytes.bytesize )
 				expect( bytes2 ).to eq( bytes )
 				expect( conn.lo_close( fd ) ).to be_nil
@@ -1030,7 +1030,7 @@ describe PG::Connection do
 				expect( res.nfields ).to eq( num_params )
 				expect( res.values ).to eq( [num_params.times.map(&:to_s)] )
 			end
-		rescue PG::ProgramLimitExceeded
+		rescue YugabyteYSQL::ProgramLimitExceeded
 			# Stop silently if the server complains about too many params
 		end
 	end
@@ -1168,7 +1168,7 @@ describe PG::Connection do
 	it "yields the result if block is given to exec" do
 		rval = @conn.exec( "select 1234::int as a union select 5678::int as a" ) do |result|
 			values = []
-			expect( result ).to be_kind_of( PG::Result )
+			expect( result ).to be_kind_of(YugabyteYSQL::Result )
 			expect( result.ntuples ).to eq( 2 )
 			result.each do |tuple|
 				values << tuple['a']
@@ -1207,7 +1207,7 @@ describe PG::Connection do
 		end
 		@conn.sync_put_copy_end
 		res = @conn.get_last_result
-		expect( res.result_status ).to eq( PG::PGRES_COMMAND_OK )
+		expect( res.result_status ).to eq(YugabyteYSQL::PGRES_COMMAND_OK )
 		@conn.exec( "DROP TABLE IF EXISTS copytable2" )
 	end
 
@@ -1215,7 +1215,7 @@ describe PG::Connection do
 		it "can process #copy_data output queries in text format" do
 			rows = []
 			res2 = @conn.copy_data( "COPY (SELECT 1 UNION ALL SELECT 2) TO STDOUT" ) do |res|
-				expect( res.result_status ).to eq( PG::PGRES_COPY_OUT )
+				expect( res.result_status ).to eq(YugabyteYSQL::PGRES_COPY_OUT )
 				expect( res.nfields ).to eq( 1 )
 				expect( res.binary_tuples ).to eq( 0 )
 				while row=@conn.get_copy_data
@@ -1223,14 +1223,14 @@ describe PG::Connection do
 				end
 			end
 			expect( rows ).to eq( ["1\n", "2\n"] )
-			expect( res2.result_status ).to eq( PG::PGRES_COMMAND_OK )
+			expect( res2.result_status ).to eq(YugabyteYSQL::PGRES_COMMAND_OK )
 			expect( @conn ).to still_be_usable
 		end
 
 		it "can process #copy_data output queries in binary format" do
 			rows = []
 			res2 = @conn.copy_data( "COPY (SELECT 1 UNION ALL SELECT 2) TO STDOUT (FORMAT binary)" ) do |res|
-				expect( res.result_status ).to eq( PG::PGRES_COPY_OUT )
+				expect( res.result_status ).to eq(YugabyteYSQL::PGRES_COPY_OUT )
 				expect( res.nfields ).to eq( 1 )
 				expect( res.binary_tuples ).to eq( 1 )
 				while row=@conn.get_copy_data
@@ -1238,7 +1238,7 @@ describe PG::Connection do
 				end
 			end
 			expect( rows ).to eq( ["PGCOPY\n\xFF\r\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01".b, "\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02".b, "\xFF\xFF".b] )
-			expect( res2.result_status ).to eq( PG::PGRES_COMMAND_OK )
+			expect( res2.result_status ).to eq(YugabyteYSQL::PGRES_COMMAND_OK )
 			expect( @conn ).to still_be_usable
 		end
 
@@ -1247,7 +1247,7 @@ describe PG::Connection do
 				@conn.copy_data( "COPY (SELECT 1 UNION ALL SELECT 2) TO STDOUT" ) do |res|
 					@conn.get_copy_data
 				end
-			}.to raise_error(PG::NotAllCopyDataRetrieved, /Not all/){|err| expect(err).to have_attributes(connection: @conn) }
+			}.to raise_error(YugabyteYSQL::NotAllCopyDataRetrieved, /Not all/){|err| expect(err).to have_attributes(connection: @conn) }
 			expect( @conn ).to still_be_usable
 		end
 
@@ -1280,7 +1280,7 @@ describe PG::Connection do
 						while @conn.get_copy_data
 						end
 					end
-				}.to raise_error(PG::Error, /test-error/){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::Error, /test-error/){|err| expect(err).to have_attributes(connection: @conn) }
 			end
 			expect( @conn ).to still_be_usable
 		end
@@ -1288,13 +1288,13 @@ describe PG::Connection do
 		it "can process #copy_data input queries in text format" do
 			@conn.exec( "CREATE TEMP TABLE copytable (col1 TEXT)" )
 			res2 = @conn.copy_data( "COPY copytable FROM STDOUT" ) do |res|
-				expect( res.result_status ).to eq( PG::PGRES_COPY_IN )
+				expect( res.result_status ).to eq(YugabyteYSQL::PGRES_COPY_IN )
 				expect( res.nfields ).to eq( 1 )
 				expect( res.binary_tuples ).to eq( 0 )
 				@conn.put_copy_data "1\n"
 				@conn.put_copy_data "2\n"
 			end
-			expect( res2.result_status ).to eq( PG::PGRES_COMMAND_OK )
+			expect( res2.result_status ).to eq(YugabyteYSQL::PGRES_COMMAND_OK )
 
 			expect( @conn ).to still_be_usable
 
@@ -1306,7 +1306,7 @@ describe PG::Connection do
 		it "can process #copy_data input queries in binary format" do
 			@conn.exec( "CREATE TEMP TABLE copytable (col1 TEXT)" )
 			res2 = @conn.copy_data( "COPY copytable FROM STDOUT (FORMAT binary)" ) do |res|
-				expect( res.result_status ).to eq( PG::PGRES_COPY_IN )
+				expect( res.result_status ).to eq(YugabyteYSQL::PGRES_COPY_IN )
 				expect( res.nfields ).to eq( 1 )
 				expect( res.binary_tuples ).to eq( 1 )
 				# header and first record ("1")
@@ -1316,7 +1316,7 @@ describe PG::Connection do
 				# trailer
 				@conn.put_copy_data "\xFF\xFF".b
 			end
-			expect( res2.result_status ).to eq( PG::PGRES_COMMAND_OK )
+			expect( res2.result_status ).to eq(YugabyteYSQL::PGRES_COMMAND_OK )
 
 			expect( @conn ).to still_be_usable
 
@@ -1365,7 +1365,7 @@ describe PG::Connection do
 					@conn.copy_data( "COPY copytable FROM STDOUT" ) do |res|
 						@conn.put_copy_data "xyz\n"
 					end
-				}.to raise_error(PG::Error, /invalid input syntax for .*integer/){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::Error, /invalid input syntax for .*integer/){|err| expect(err).to have_attributes(connection: @conn) }
 			end
 			expect( @conn ).to still_be_usable
 			@conn.exec( "DROP TABLE IF EXISTS copytable" )
@@ -1393,7 +1393,7 @@ describe PG::Connection do
 				@conn.copy_data( "COPY copytable FROM STDOUT" ) do |res|
 					@conn.exec "SELECT 1"
 				end
-			}.to raise_error(PG::LostCopyState, /another SQL query/){|err| expect(err).to have_attributes(connection: @conn) }
+			}.to raise_error(YugabyteYSQL::LostCopyState, /another SQL query/){|err| expect(err).to have_attributes(connection: @conn) }
 			expect( @conn ).to still_be_usable
 			@conn.exec( "DROP TABLE copytable" )
 		end
@@ -1404,7 +1404,7 @@ describe PG::Connection do
 				@conn.copy_data( "COPY (VALUES(1), (2)) TO STDOUT" ) do |res|
 					@conn.exec "SELECT 3"
 				end
-			}.to raise_error(PG::LostCopyState, /another SQL query/){|err| expect(err).to have_attributes(connection: @conn) }
+			}.to raise_error(YugabyteYSQL::LostCopyState, /another SQL query/){|err| expect(err).to have_attributes(connection: @conn) }
 			expect( @conn ).to still_be_usable
 		end
 
@@ -1420,7 +1420,7 @@ describe PG::Connection do
 			@conn.setnonblocking(true)
 			expect {
 				@conn.copy_data( "COPY copytable FROM STDOUT" )
-			}.to raise_error(PG::NotInBlockingMode){|err| expect(err).to have_attributes(connection: @conn) }
+			}.to raise_error(YugabyteYSQL::NotInBlockingMode){|err| expect(err).to have_attributes(connection: @conn) }
 			@conn.setnonblocking(false)
 		end
 	end
@@ -1501,7 +1501,7 @@ describe PG::Connection do
 
 
 	it "honors the connect_timeout connection parameter" do
-		conn = PG.connect( port: @port, dbname: 'test', connect_timeout: 11 )
+		conn = YugabyteYSQL.connect(port: @port, dbname: 'test', connect_timeout: 11 )
 		begin
 			expect( conn.conninfo_hash[:connect_timeout] ).to eq( "11" )
 		ensure
@@ -1553,7 +1553,7 @@ describe PG::Connection do
 			}.to raise_error( TypeError )
 			expect {
 				@conn.encrypt_password( "postgres", "postgres", "invalid" )
-			}.to raise_error( PG::Error, /unrecognized/ )
+			}.to raise_error(YugabyteYSQL::Error, /unrecognized/ )
 		end
 	end
 
@@ -1599,13 +1599,13 @@ describe PG::Connection do
 	it "handles server close while asynchronous connect" do
 		serv = TCPServer.new( '127.0.0.1', 54320 )
 		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
-		expect( [PG::PGRES_POLLING_WRITING, PG::CONNECTION_OK] ).to include conn.connect_poll
+		expect( [YugabyteYSQL::PGRES_POLLING_WRITING, YugabyteYSQL::CONNECTION_OK] ).to include conn.connect_poll
 		select( nil, [conn.socket_io], nil, 0.2 )
 		serv.close
-		if conn.connect_poll == PG::PGRES_POLLING_READING
+		if conn.connect_poll == YugabyteYSQL::PGRES_POLLING_READING
 			select( [conn.socket_io], nil, nil, 0.2 )
 		end
-		expect( conn.connect_poll ).to eq( PG::PGRES_POLLING_FAILED )
+		expect( conn.connect_poll ).to eq(YugabyteYSQL::PGRES_POLLING_FAILED )
 	end
 
 	describe "#discard_results" do
@@ -1635,7 +1635,7 @@ describe PG::Connection do
 		end
 
 		it "returns false on connection failures" do
-			conn = PG.connect(@conninfo)
+			conn = YugabyteYSQL.connect(@conninfo)
 			conn.send_query("select pg_terminate_backend(pg_backend_pid());")
 			expect( conn.discard_results ).to eq( false )
 		end
@@ -1662,22 +1662,22 @@ describe PG::Connection do
 	end
 
 	it "carries the connection in case of connection errors" do
-		conn = PG.connect(@conninfo)
+		conn = YugabyteYSQL.connect(@conninfo)
 		expect {
 			conn.exec("select pg_terminate_backend(pg_backend_pid());")
-		}.to raise_error(PG::Error, /connection has been closed|terminating connection|server closed the connection unexpectedly/i){|err| expect(err).to have_attributes(connection: conn) }
+		}.to raise_error(YugabyteYSQL::Error, /connection has been closed|terminating connection|server closed the connection unexpectedly/i){|err| expect(err).to have_attributes(connection: conn) }
 	end
 
 	it "raises a rescue-able error if #finish is called twice", :without_transaction do
-		conn = PG.connect( @conninfo )
+		conn = YugabyteYSQL.connect(@conninfo )
 
 		conn.finish
-		expect { conn.finish }.to raise_error( PG::ConnectionBad, /connection is closed/i ){|err| expect(err).to have_attributes(connection: conn) }
+		expect { conn.finish }.to raise_error(YugabyteYSQL::ConnectionBad, /connection is closed/i ){|err| expect(err).to have_attributes(connection: conn) }
 	end
 
 	it "can use conn.reset to restart the connection" do
 		ios = IO.pipe
-		conn = PG.connect( @conninfo )
+		conn = YugabyteYSQL.connect(@conninfo )
 
 		# Close the two pipe file descriptors, so that the file descriptor of
 		# newly established connection is probably distinct from the previous one.
@@ -1703,20 +1703,20 @@ describe PG::Connection do
 		expect do
 			conn.reset
 			conn.exec("select 1")
-		end.to raise_error(PG::Error)
+		end.to raise_error(YugabyteYSQL::Error)
 	end
 
 
 	it "closes the IO fetched from #socket_io when the connection is closed", :without_transaction do
-		conn = PG.connect( @conninfo )
+		conn = YugabyteYSQL.connect(@conninfo )
 		io = conn.socket_io
 		conn.finish
 		expect( io ).to be_closed()
-		expect { conn.socket_io }.to raise_error( PG::ConnectionBad, /connection is closed/i ){|err| expect(err).to have_attributes(connection: conn) }
+		expect { conn.socket_io }.to raise_error(YugabyteYSQL::ConnectionBad, /connection is closed/i ){|err| expect(err).to have_attributes(connection: conn) }
 	end
 
 	it "closes the IO fetched from #socket_io when the connection is reset", :without_transaction do
-		conn = PG.connect( @conninfo )
+		conn = YugabyteYSQL.connect(@conninfo )
 		io = conn.socket_io
 		conn.reset
 		expect( io ).to be_closed()
@@ -1727,12 +1727,12 @@ describe PG::Connection do
 	it "consume_input should raise ConnectionBad for a closed connection" do
 		serv = TCPServer.new( '127.0.0.1', 54320 )
 		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
-		while [PG::CONNECTION_STARTED, PG::CONNECTION_MADE].include?(conn.connect_poll)
+		while [YugabyteYSQL::CONNECTION_STARTED, YugabyteYSQL::CONNECTION_MADE].include?(conn.connect_poll)
 			sleep 0.1
 		end
 		serv.close
-		expect{ conn.consume_input }.to raise_error(PG::ConnectionBad, /server closed the connection unexpectedly/){|err| expect(err).to have_attributes(connection: conn) }
-		expect{ conn.consume_input }.to raise_error(PG::ConnectionBad, /can't get socket descriptor|connection not open/){|err| expect(err).to have_attributes(connection: conn) }
+		expect{ conn.consume_input }.to raise_error(YugabyteYSQL::ConnectionBad, /server closed the connection unexpectedly/){|err| expect(err).to have_attributes(connection: conn) }
+		expect{ conn.consume_input }.to raise_error(YugabyteYSQL::ConnectionBad, /can't get socket descriptor|connection not open/){|err| expect(err).to have_attributes(connection: conn) }
 	end
 
 	describe :check_socket do
@@ -1750,23 +1750,23 @@ describe PG::Connection do
 		end
 
 		it "raises error on broken connection" do
-			conn = PG.connect(@conninfo)
+			conn = YugabyteYSQL.connect(@conninfo)
 			conn.send_query "SELECT pg_terminate_backend(pg_backend_pid())"
 			expect do
 				# Windows sometimes delivers the socket error prematurely in get_result, due a bug in the TCP stack
-				expect( conn.get_result.result_status ).to be( PG::PGRES_FATAL_ERROR )
+				expect( conn.get_result.result_status ).to be(YugabyteYSQL::PGRES_FATAL_ERROR )
 
 				wait_check_socket(conn)
-			end.to raise_error(PG::ConnectionBad, /SSL connection has been closed unexpectedly|server closed the connection unexpectedly/)
+			end.to raise_error(YugabyteYSQL::ConnectionBad, /SSL connection has been closed unexpectedly|server closed the connection unexpectedly/)
 		end
 
 		it "processes messages before connection error" do
-			conn = PG.connect(@conninfo)
+			conn = YugabyteYSQL.connect(@conninfo)
 			conn.send_query "do $$ BEGIN RAISE NOTICE 'foo'; PERFORM pg_terminate_backend(pg_backend_pid()); END; $$ LANGUAGE plpgsql;"
 
 			expect do
 				wait_check_socket(conn)
-			end.to raise_error(PG::ConnectionBad, /SSL connection has been closed unexpectedly|server closed the connection unexpectedly/)
+			end.to raise_error(YugabyteYSQL::ConnectionBad, /SSL connection has been closed unexpectedly|server closed the connection unexpectedly/)
 		end
 	end
 
@@ -1891,12 +1891,12 @@ describe PG::Connection do
 
 		it "pings successfully with connection string" do
 			ping = described_class.ping(@conninfo)
-			expect( ping ).to eq( PG::PQPING_OK )
+			expect( ping ).to eq(YugabyteYSQL::PQPING_OK )
 		end
 
 		it "pings using 7 arguments converted to strings" do
 			ping = described_class.ping('localhost', @port, nil, nil, :test, nil, nil)
-			expect( ping ).to eq( PG::PQPING_OK )
+			expect( ping ).to eq(YugabyteYSQL::PQPING_OK )
 		end
 
 		it "pings using a hash of connection parameters" do
@@ -1904,7 +1904,7 @@ describe PG::Connection do
 				:host => 'localhost',
 				:port => @port,
 				:dbname => :test)
-			expect( ping ).to eq( PG::PQPING_OK )
+			expect( ping ).to eq(YugabyteYSQL::PQPING_OK )
 		end
 
 		it "returns correct response when ping connection cannot be established" do
@@ -1912,12 +1912,12 @@ describe PG::Connection do
 				:host => 'localhost',
 				:port => 9999,
 				:dbname => :test)
-			expect( ping ).to eq( PG::PQPING_NO_RESPONSE )
+			expect( ping ).to eq(YugabyteYSQL::PQPING_NO_RESPONSE )
 		end
 
 		it "returns error when ping connection arguments are wrong" do
 			ping = described_class.ping('localhost', 'localhost', nil, nil, :test, nil, nil)
-			expect( ping ).to_not eq( PG::PQPING_OK )
+			expect( ping ).to_not eq(YugabyteYSQL::PQPING_OK )
 		end
 
 		it "returns correct response when ping connection arguments are wrong" do
@@ -1925,7 +1925,7 @@ describe PG::Connection do
 				:host => 'localhost',
 				:invalid_option => 9999,
 				:dbname => :test)
-			expect( ping ).to eq( PG::PQPING_NO_ATTEMPT )
+			expect( ping ).to eq(YugabyteYSQL::PQPING_NO_ATTEMPT )
 		end
 
 	end
@@ -1935,7 +1935,7 @@ describe PG::Connection do
 		it "raises an error when called at the wrong time" do
 			expect {
 				@conn.set_single_row_mode
-			}.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
+			}.to raise_error(YugabyteYSQL::Error){|err| expect(err).to have_attributes(connection: @conn) }
 		end
 
 		it "should work in single row mode" do
@@ -1950,12 +1950,12 @@ describe PG::Connection do
 			end
 			expect( results.length ).to eq( 11 )
 			results[0..-2].each do |res|
-				expect( res.result_status ).to eq( PG::PGRES_SINGLE_TUPLE )
+				expect( res.result_status ).to eq(YugabyteYSQL::PGRES_SINGLE_TUPLE )
 				values = res.field_values('generate_series')
 				expect( values.length ).to eq( 1 )
 				expect( values.first.to_i ).to be > 0
 			end
-			expect( results.last.result_status ).to eq( PG::PGRES_TUPLES_OK )
+			expect( results.last.result_status ).to eq(YugabyteYSQL::PGRES_TUPLES_OK )
 			expect( results.last.ntuples ).to eq( 0 )
 		end
 
@@ -1984,9 +1984,9 @@ describe PG::Connection do
 					res.check
 					first_result ||= res
 				end
-			end.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
-			expect( first_result.kind_of?(PG::Result) ).to be_truthy
-			expect( first_result.result_status ).to eq( PG::PGRES_SINGLE_TUPLE )
+			end.to raise_error(YugabyteYSQL::Error){|err| expect(err).to have_attributes(connection: @conn) }
+			expect( first_result.kind_of?(YugabyteYSQL::Result) ).to be_truthy
+			expect( first_result.result_status ).to eq(YugabyteYSQL::PGRES_SINGLE_TUPLE )
 		end
 
 	end
@@ -1996,9 +1996,9 @@ describe PG::Connection do
 		describe "pipeline_status" do
 			it "can enter and exit the pipeline mode" do
 				@conn.enter_pipeline_mode
-				expect( @conn.pipeline_status ).to eq( PG::PQ_PIPELINE_ON )
+				expect( @conn.pipeline_status ).to eq(YugabyteYSQL::PQ_PIPELINE_ON )
 				@conn.exit_pipeline_mode
-				expect( @conn.pipeline_status ).to eq( PG::PQ_PIPELINE_OFF )
+				expect( @conn.pipeline_status ).to eq(YugabyteYSQL::PQ_PIPELINE_OFF )
 			end
 		end
 
@@ -2006,14 +2006,14 @@ describe PG::Connection do
 			it "does nothing if already in pipeline mode" do
 				@conn.enter_pipeline_mode
 				@conn.enter_pipeline_mode
-				expect( @conn.pipeline_status ).to eq( PG::PQ_PIPELINE_ON )
+				expect( @conn.pipeline_status ).to eq(YugabyteYSQL::PQ_PIPELINE_ON )
 			end
 
 			it "raises an error when called with pending results" do
 				@conn.send_query_params "select 1", []
 				expect {
 					@conn.enter_pipeline_mode
-				}.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::Error){|err| expect(err).to have_attributes(connection: @conn) }
 				@conn.get_last_result
 			end
 		end
@@ -2021,7 +2021,7 @@ describe PG::Connection do
 		describe "exit_pipeline_mode" do
 			it "does nothing if not in pipeline mode" do
 				@conn.exit_pipeline_mode
-				expect( @conn.pipeline_status ).to eq( PG::PQ_PIPELINE_OFF )
+				expect( @conn.pipeline_status ).to eq(YugabyteYSQL::PQ_PIPELINE_OFF )
 			end
 
 			it "raises an error when called with pending results" do
@@ -2029,7 +2029,7 @@ describe PG::Connection do
 				@conn.send_query_params "select 1", []
 				expect {
 					@conn.exit_pipeline_mode
-				}.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::Error){|err| expect(err).to have_attributes(connection: @conn) }
 				@conn.pipeline_sync
 				@conn.get_last_result
 			end
@@ -2040,9 +2040,9 @@ describe PG::Connection do
 				@conn.enter_pipeline_mode
 				@conn.send_query_params "select 6", []
 				@conn.pipeline_sync
-				expect( @conn.get_result.result_status ).to eq( PG::PGRES_TUPLES_OK )
+				expect( @conn.get_result.result_status ).to eq(YugabyteYSQL::PGRES_TUPLES_OK )
 				expect( @conn.get_result ).to be_nil
-				expect( @conn.get_result.result_status ).to eq( PG::PGRES_PIPELINE_SYNC )
+				expect( @conn.get_result.result_status ).to eq(YugabyteYSQL::PGRES_PIPELINE_SYNC )
 				expect( @conn.get_result ).to be_nil
 				expect( @conn.get_result ).to be_nil
 				@conn.exit_pipeline_mode
@@ -2051,7 +2051,7 @@ describe PG::Connection do
 			it "raises an error when not in pipeline mode" do
 				expect {
 					@conn.pipeline_sync
-				}.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::Error){|err| expect(err).to have_attributes(connection: @conn) }
 			end
 		end
 
@@ -2061,7 +2061,7 @@ describe PG::Connection do
 				@conn.send_query_params "select 1", []
 				@conn.send_flush_request
 				@conn.flush
-				expect( @conn.get_result.result_status ).to eq( PG::PGRES_TUPLES_OK )
+				expect( @conn.get_result.result_status ).to eq(YugabyteYSQL::PGRES_TUPLES_OK )
 				expect( @conn.get_result ).to be_nil
 				expect( @conn.get_result ).to be_nil
 			end
@@ -2070,7 +2070,7 @@ describe PG::Connection do
 				@conn.send_query_params "select 1", []
 				expect {
 					@conn.send_flush_request
-				}.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::Error){|err| expect(err).to have_attributes(connection: @conn) }
 			end
 		end
 
@@ -2080,7 +2080,7 @@ describe PG::Connection do
 				@conn.send_query_params "select 6", []
 				@conn.pipeline_sync
 				expect( @conn.get_last_result.values ).to eq( [["6"]] )
-				expect( @conn.get_last_result.result_status ).to eq( PG::PGRES_PIPELINE_SYNC )
+				expect( @conn.get_last_result.result_status ).to eq(YugabyteYSQL::PGRES_PIPELINE_SYNC )
 				@conn.exit_pipeline_mode
 			end
 
@@ -2091,16 +2091,16 @@ describe PG::Connection do
 				@conn.pipeline_sync
 				begin
 					@conn.get_last_result
-				rescue PG::SyntaxError => err1
+				rescue YugabyteYSQL::SyntaxError => err1
 				end
-				expect( err1.result.result_status ).to eq( PG::PGRES_FATAL_ERROR )
+				expect( err1.result.result_status ).to eq(YugabyteYSQL::PGRES_FATAL_ERROR )
 				begin
 					@conn.get_last_result
-				rescue PG::UnableToSend => err2
+				rescue YugabyteYSQL::UnableToSend => err2
 				end
-				expect( err2.result.result_status ).to eq( PG::PGRES_PIPELINE_ABORTED )
-				expect( @conn.pipeline_status ).to eq( PG::PQ_PIPELINE_ABORTED )
-				expect( @conn.get_last_result.result_status ).to eq( PG::PGRES_PIPELINE_SYNC )
+				expect( err2.result.result_status ).to eq(YugabyteYSQL::PGRES_PIPELINE_ABORTED )
+				expect( @conn.pipeline_status ).to eq(YugabyteYSQL::PQ_PIPELINE_ABORTED )
+				expect( @conn.get_last_result.result_status ).to eq(YugabyteYSQL::PGRES_PIPELINE_SYNC )
 				@conn.exit_pipeline_mode
 			end
 		end
@@ -2215,7 +2215,7 @@ describe PG::Connection do
 			end
 
 			it "raises appropriate error if set_client_encoding is called with invalid arguments" do
-				expect { @conn.set_client_encoding( "invalid" ) }.to raise_error(PG::Error, /invalid value/){|err| expect(err).to have_attributes(connection: @conn) }
+				expect { @conn.set_client_encoding( "invalid" ) }.to raise_error(YugabyteYSQL::Error, /invalid value/){|err| expect(err).to have_attributes(connection: @conn) }
 				expect { @conn.set_client_encoding( :invalid ) }.to raise_error(TypeError)
 				expect { @conn.set_client_encoding( nil ) }.to raise_error(TypeError)
 			end
@@ -2374,7 +2374,7 @@ describe PG::Connection do
 					prev_encoding = Encoding.default_internal
 					Encoding.default_internal = Encoding::ISO8859_2
 
-					conn = PG.connect( @conninfo )
+					conn = YugabyteYSQL.connect(@conninfo )
 					expect( conn.internal_encoding ).to eq( Encoding::ISO8859_2 )
 					res = conn.exec( "SELECT foo FROM defaultinternaltest" )
 					expect( res[0]['foo'].encoding ).to eq( Encoding::ISO8859_2 )
@@ -2391,7 +2391,7 @@ describe PG::Connection do
 					Encoding.default_internal = Encoding::UTF_8
 
 					# PG.connect shouldn't emit a "set client_encoding" for UTF_8, since the server is already on UTF8.
-					conn = PG.connect( @conninfo )
+					conn = YugabyteYSQL.connect(@conninfo )
 					expect( conn.internal_encoding ).to eq( Encoding::UTF_8 )
 					res = conn.exec( "SELECT setting, source FROM pg_settings WHERE name='client_encoding'" )
 					expect( res[0].values ).to eq( ['UTF8', 'default'] )
@@ -2419,7 +2419,7 @@ describe PG::Connection do
 
 		it "encodes exception messages with the connection's encoding (#96)", :without_transaction do
 			# Use a new connection so the client_encoding isn't set outside of this example
-			conn = PG.connect( @conninfo )
+			conn = YugabyteYSQL.connect(@conninfo )
 			conn.client_encoding = 'iso-8859-15'
 
 			conn.transaction do
@@ -2446,7 +2446,7 @@ describe PG::Connection do
 			end
 			@conn.exec "do $$ BEGIN RAISE NOTICE 'foo'; END; $$ LANGUAGE plpgsql;"
 			sleep 0.2
-			expect( r ).to be_a( PG::Result )
+			expect( r ).to be_a(YugabyteYSQL::Result )
 			expect( r.cleared? ).to eq(true)
 			expect( r.autoclear? ).to eq(true)
 			r.clear
@@ -2521,15 +2521,15 @@ describe PG::Connection do
 		end
 
 		it "should return nil if no type mapping is set" do
-			expect( @conn.type_map_for_queries ).to be_kind_of(PG::TypeMapAllStrings)
-			expect( @conn.type_map_for_results ).to be_kind_of(PG::TypeMapAllStrings)
+			expect( @conn.type_map_for_queries ).to be_kind_of(YugabyteYSQL::TypeMapAllStrings)
+			expect( @conn.type_map_for_results ).to be_kind_of(YugabyteYSQL::TypeMapAllStrings)
 		end
 
 		it "shouldn't type map params unless requested" do
 			if @conn.server_version < 100000
 				expect{
 					@conn.exec_params( "SELECT $1", [5] )
-				}.to raise_error(PG::IndeterminateDatatype){|err| expect(err).to have_attributes(connection: @conn) }
+				}.to raise_error(YugabyteYSQL::IndeterminateDatatype){|err| expect(err).to have_attributes(connection: @conn) }
 			else
 				# PostgreSQL-10 maps to TEXT type (OID 25)
 				expect( @conn.exec_params( "SELECT $1", [5] ).ftype(0)).to eq(25)
@@ -2543,8 +2543,8 @@ describe PG::Connection do
 		end
 
 		it "can type cast parameters to put_copy_data with explicit encoder" do
-			tm = PG::TypeMapByColumn.new [nil]
-			row_encoder = PG::TextEncoder::CopyRow.new type_map: tm
+			tm = YugabyteYSQL::TypeMapByColumn.new [nil]
+			row_encoder = YugabyteYSQL::TextEncoder::CopyRow.new type_map: tm
 
 			@conn.exec( "CREATE TEMP TABLE copytable (col1 TEXT)" )
 			@conn.copy_data( "COPY copytable FROM STDOUT" ) do |res|
@@ -2564,11 +2564,11 @@ describe PG::Connection do
 		context "with default query type map" do
 			before :each do
 				@conn2 = described_class.new(@conninfo)
-				tm = PG::TypeMapByClass.new
-				tm[Integer] = PG::TextEncoder::Integer.new oid: 20
+				tm = YugabyteYSQL::TypeMapByClass.new
+				tm[Integer] = YugabyteYSQL::TextEncoder::Integer.new oid: 20
 				@conn2.type_map_for_queries = tm
 
-				row_encoder = PG::TextEncoder::CopyRow.new type_map: tm
+				row_encoder = YugabyteYSQL::TextEncoder::CopyRow.new type_map: tm
 				@conn2.encoder_for_put_copy_data = row_encoder
 			end
 			after :each do
@@ -2582,7 +2582,7 @@ describe PG::Connection do
 			end
 
 			it "should return the current type mapping" do
-				expect( @conn2.type_map_for_queries ).to be_kind_of(PG::TypeMapByClass)
+				expect( @conn2.type_map_for_queries ).to be_kind_of(YugabyteYSQL::TypeMapByClass)
 			end
 
 			it "should work with arbitrary number of params in conjunction with type casting" do
@@ -2595,7 +2595,7 @@ describe PG::Connection do
 						expect( res.nfields ).to eq( num_params )
 						expect( res.values ).to eq( [num_params.times.map(&:to_s)] )
 					end
-				rescue PG::ProgramLimitExceeded
+				rescue YugabyteYSQL::ProgramLimitExceeded
 					# Stop silently as soon the server complains about too many params
 				end
 			end
@@ -2615,11 +2615,11 @@ describe PG::Connection do
 		context "with default result type map" do
 			before :each do
 				@conn2 = described_class.new(@conninfo)
-				tm = PG::TypeMapByOid.new
-				tm.add_coder PG::TextDecoder::Integer.new oid: 23, format: 0
+				tm = YugabyteYSQL::TypeMapByOid.new
+				tm.add_coder YugabyteYSQL::TextDecoder::Integer.new oid: 23, format: 0
 				@conn2.type_map_for_results = tm
 
-				row_decoder = PG::TextDecoder::CopyRow.new
+				row_decoder = YugabyteYSQL::TextDecoder::CopyRow.new
 				@conn2.decoder_for_get_copy_data = row_decoder
 			end
 			after :each do
@@ -2632,7 +2632,7 @@ describe PG::Connection do
 			end
 
 			it "should return the current type mapping" do
-				expect( @conn2.type_map_for_results ).to be_kind_of(PG::TypeMapByOid)
+				expect( @conn2.type_map_for_results ).to be_kind_of(YugabyteYSQL::TypeMapByOid)
 			end
 
 			it "should work with arbitrary number of params in conjunction with type casting" do
@@ -2645,7 +2645,7 @@ describe PG::Connection do
 						expect( res.nfields ).to eq( num_params )
 						expect( res.values ).to eq( [num_params.times.to_a] )
 					end
-				rescue PG::ProgramLimitExceeded
+				rescue YugabyteYSQL::ProgramLimitExceeded
 					# Stop silently as soon the server complains about too many params
 				end
 			end
@@ -2663,8 +2663,8 @@ describe PG::Connection do
 			end
 
 			it "can type cast #copy_data output with explicit decoder" do
-				tm = PG::TypeMapByColumn.new [PG::TextDecoder::Integer.new]
-				row_decoder = PG::TextDecoder::CopyRow.new type_map: tm
+				tm = YugabyteYSQL::TypeMapByColumn.new [YugabyteYSQL::TextDecoder::Integer.new]
+				row_decoder = YugabyteYSQL::TextDecoder::CopyRow.new type_map: tm
 				rows = []
 				@conn.copy_data( "COPY (SELECT 1 UNION ALL SELECT 2) TO STDOUT", row_decoder ) do |res|
 					while row=@conn.get_copy_data
@@ -2683,7 +2683,7 @@ describe PG::Connection do
 
 	describe :field_name_type do
 		before :each do
-			@conn2 = PG.connect(@conninfo)
+			@conn2 = YugabyteYSQL.connect(@conninfo)
 		end
 		after :each do
 			@conn2.close
@@ -2716,7 +2716,7 @@ describe PG::Connection do
 	end
 
 	describe "deprecated forms of methods" do
-		if PG::VERSION < "2"
+		if YugabyteYSQL::VERSION < "2"
 			it "should forward exec to exec_params" do
 				res = @conn.exec("VALUES($1::INT)", [7]).values
 				expect(res).to eq( [["7"]] )

--- a/spec/pg/connection_sync_spec.rb
+++ b/spec/pg/connection_sync_spec.rb
@@ -6,19 +6,19 @@ require_relative '../helpers'
 context "running with sync_* methods" do
 	before :all do
 		@conn.finish
-		PG::Connection.async_api = false
+		YugabyteYSQL::Connection.async_api = false
 		@conn = $pg_server.connect
 	end
 
 	after :all do
-		PG::Connection.async_api = true
+		YugabyteYSQL::Connection.async_api = true
 	end
 
 	fname = File.expand_path("../connection_spec.rb", __FILE__)
 	eval File.read(fname, encoding: __ENCODING__), binding, fname
 
 	it "enables async methods by #async_api" do
-		PG::Connection.async_api = true
+		YugabyteYSQL::Connection.async_api = true
 
 		start = Time.now
 		t = Thread.new do
@@ -32,11 +32,11 @@ context "running with sync_* methods" do
 		expect( Time.now - start ).to be < 0.9
 		@conn.cancel
 	ensure
-		PG::Connection.async_api = false
+		YugabyteYSQL::Connection.async_api = false
 	end
 
 	it "disables async methods by #async_api" do
-		PG::Connection.async_api = false
+		YugabyteYSQL::Connection.async_api = false
 
 		start = Time.now
 		t = Thread.new do

--- a/spec/pg/exceptions_spec.rb
+++ b/spec/pg/exceptions_spec.rb
@@ -3,32 +3,32 @@
 
 require_relative '../helpers'
 
-require 'pg'
+require 'yugabyte_ysql'
 
-describe PG::Error do
+describe YugabyteYSQL::Error do
 
 	it "does have hierarchical error classes" do
-		expect( PG::UndefinedTable.ancestors[0,4] ).to eq([
-				PG::UndefinedTable,
-				PG::SyntaxErrorOrAccessRuleViolation,
-				PG::ServerError,
-		        PG::Error
+		expect(YugabyteYSQL::UndefinedTable.ancestors[0, 4] ).to eq([
+                                                                  YugabyteYSQL::UndefinedTable,
+                                                                  YugabyteYSQL::SyntaxErrorOrAccessRuleViolation,
+                                                                  YugabyteYSQL::ServerError,
+                                                                  YugabyteYSQL::Error
 		        ])
 
-		expect( PG::InvalidSchemaName.ancestors[0,3] ).to eq([
-				PG::InvalidSchemaName,
-				PG::ServerError,
-		        PG::Error
+		expect(YugabyteYSQL::InvalidSchemaName.ancestors[0, 3] ).to eq([
+                                                                     YugabyteYSQL::InvalidSchemaName,
+                                                                     YugabyteYSQL::ServerError,
+                                                                     YugabyteYSQL::Error
 		        ])
 	end
 
 	it "can be used to raise errors without text" do
-		expect{ raise PG::InvalidTextRepresentation }.to raise_error(PG::InvalidTextRepresentation)
+		expect{ raise YugabyteYSQL::InvalidTextRepresentation }.to raise_error(YugabyteYSQL::InvalidTextRepresentation)
 	end
 
 	it "should be delivered by Ractor", :ractor do
 		r = Ractor.new(@conninfo) do |conninfo|
-			conn = PG.connect(conninfo)
+			conn = YugabyteYSQL.connect(conninfo)
 			conn.exec("SELECT 0/0")
 		ensure
 			conn&.finish
@@ -39,8 +39,8 @@ describe PG::Error do
 		rescue Exception => err
 		end
 
-		expect( err.cause ).to be_kind_of(PG::Error)
-		expect{ raise err.cause }.to raise_error(PG::DivisionByZero, /division by zero/)
+		expect( err.cause ).to be_kind_of(YugabyteYSQL::Error)
+		expect{ raise err.cause }.to raise_error(YugabyteYSQL::DivisionByZero, /division by zero/)
 		expect{ raise err }.to raise_error(Ractor::RemoteError)
 	end
 end

--- a/spec/pg/gc_compact_spec.rb
+++ b/spec/pg/gc_compact_spec.rb
@@ -25,31 +25,31 @@ require_relative '../helpers'
 
 describe "GC.compact", if: GC.respond_to?(:compact) do
 	before :all do
-		TM1 = Class.new(PG::TypeMapByClass) do
+		TM1 = Class.new(YugabyteYSQL::TypeMapByClass) do
 			def conv_array(value)
-				PG::TextEncoder::JSON.new
+				YugabyteYSQL::TextEncoder::JSON.new
 			end
 		end.new
 		TM1[Array] = :conv_array
 
-		E1 = PG::TextEncoder::JSON.new
+		E1 = YugabyteYSQL::TextEncoder::JSON.new
 
-		TM2 = PG::TypeMapByClass.new
-		TM2.default_type_map = PG::TypeMapInRuby.new
+		TM2 = YugabyteYSQL::TypeMapByClass.new
+		TM2.default_type_map = YugabyteYSQL::TypeMapInRuby.new
 
-		TMBC = PG::TypeMapByColumn.new([PG::TextDecoder::Float.new])
+		TMBC = YugabyteYSQL::TypeMapByColumn.new([YugabyteYSQL::TextDecoder::Float.new])
 
 
-		CONN2 = PG.connect(@conninfo)
-		CONN2.type_map_for_results = PG::BasicTypeMapForResults.new(CONN2)
+		CONN2 = YugabyteYSQL.connect(@conninfo)
+		CONN2.type_map_for_results = YugabyteYSQL::BasicTypeMapForResults.new(CONN2)
 
 		RES1 = CONN2.exec("SELECT 234")
 
 		TUP1 = RES1.tuple(0)
 
-		TM3 = PG::TypeMapByClass.new
-		CPYENC = PG::TextEncoder::CopyRow.new type_map: TM3
-		RECENC = PG::TextEncoder::Record.new type_map: TM3
+		TM3 = YugabyteYSQL::TypeMapByClass.new
+		CPYENC = YugabyteYSQL::TextEncoder::CopyRow.new type_map: TM3
+		RECENC = YugabyteYSQL::TextEncoder::Record.new type_map: TM3
 
 		begin
 			# Use GC.verify_compaction_references instead of GC.compact .
@@ -68,12 +68,12 @@ describe "GC.compact", if: GC.respond_to?(:compact) do
 	end
 
 	it "should compact PG::CompositeCoder #327" do
-		e2 = PG::TextEncoder::Array.new elements_type: E1
+		e2 = YugabyteYSQL::TextEncoder::Array.new elements_type: E1
 		expect( e2.encode([5]) ).to eq("{5}")
 	end
 
 	it "should compact PG::TypeMap#default_type_map" do
-		expect( TM2.default_type_map ).to be_kind_of( PG::TypeMapInRuby )
+		expect( TM2.default_type_map ).to be_kind_of(YugabyteYSQL::TypeMapInRuby )
 	end
 
 	it "should compact PG::TypeMapByColumn" do
@@ -82,7 +82,7 @@ describe "GC.compact", if: GC.respond_to?(:compact) do
 	end
 
 	it "should compact PG::Connection" do
-		expect( TMBC.coders[0] ).to be_kind_of(PG::TextDecoder::Float)
+		expect( TMBC.coders[0] ).to be_kind_of(YugabyteYSQL::TextDecoder::Float)
 	end
 
 	it "should compact PG::Result" do

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -3,26 +3,26 @@
 
 require_relative '../helpers'
 
-require 'pg'
+require 'yugabyte_ysql'
 
 
-describe PG::Result do
+describe YugabyteYSQL::Result do
 
 	it "provides res_status" do
-		str = PG::Result.res_status(PG::PGRES_EMPTY_QUERY)
+		str = YugabyteYSQL::Result.res_status(YugabyteYSQL::PGRES_EMPTY_QUERY)
 		expect( str ).to eq("PGRES_EMPTY_QUERY")
 		expect( str.encoding ).to eq(Encoding::UTF_8)
 
 		res = @conn.exec("SELECT 1")
 		expect( res.res_status ).to eq("PGRES_TUPLES_OK")
-		expect( res.res_status(PG::PGRES_FATAL_ERROR) ).to eq("PGRES_FATAL_ERROR")
+		expect( res.res_status(YugabyteYSQL::PGRES_FATAL_ERROR) ).to eq("PGRES_FATAL_ERROR")
 
 		expect{ res.res_status(1,2) }.to raise_error(ArgumentError)
 	end
 
 	it "should deny changes when frozen" do
 		res = @conn.exec("SELECT 1").freeze
-		expect{ res.type_map = PG::TypeMapAllStrings.new }.to raise_error(FrozenError)
+		expect{ res.type_map = YugabyteYSQL::TypeMapAllStrings.new }.to raise_error(FrozenError)
 		expect{ res.field_name_type = :symbol  }.to raise_error(FrozenError)
 		expect{ res.clear }.to raise_error(FrozenError)
 	end
@@ -34,13 +34,13 @@ describe PG::Result do
 
 	it "should be usable with Ractor", :ractor do
 		res = Ractor.new(@conninfo) do |conninfo|
-			conn = PG.connect(conninfo)
+			conn = YugabyteYSQL.connect(conninfo)
 			conn.exec("SELECT 123 as col")
 		ensure
 			conn&.finish
 		end.take
 
-		expect( res ).to be_kind_of( PG::Result )
+		expect( res ).to be_kind_of(YugabyteYSQL::Result )
 		expect( res.fields ).to eq( ["col"] )
 		expect( res.values ).to eq( [["123"]] )
 	end
@@ -129,7 +129,7 @@ describe PG::Result do
 	end
 
 	context "result streaming in single row mode" do
-		let!(:textdec_int){ PG::TextDecoder::Integer.new name: 'INT4', oid: 23 }
+		let!(:textdec_int){ YugabyteYSQL::TextDecoder::Integer.new name: 'INT4', oid: 23 }
 
 		it "can iterate over all rows as Hash" do
 			@conn.send_query( "SELECT generate_series(2,4) AS a; SELECT 1 AS b, generate_series(5,6) AS c" )
@@ -151,7 +151,7 @@ describe PG::Result do
 			@conn.send_query( "SELECT generate_series(2,4) AS a" )
 			@conn.set_single_row_mode
 			res = @conn.get_result.field_names_as(:symbol)
-			res.type_map = PG::TypeMapByColumn.new [textdec_int]
+			res.type_map = YugabyteYSQL::TypeMapByColumn.new [textdec_int]
 			expect(
 				res.stream_each.to_a
 			).to eq(
@@ -239,7 +239,7 @@ describe PG::Result do
 			@conn.send_query( "SELECT generate_series(2,4) AS a" )
 			@conn.set_single_row_mode
 			res = @conn.get_result.field_names_as(:symbol)
-			res.type_map = PG::TypeMapByColumn.new [textdec_int]
+			res.type_map = YugabyteYSQL::TypeMapByColumn.new [textdec_int]
 			tuples = res.stream_each_tuple.to_a
 			expect( tuples[0][0] ).to eq( 2 )
 			expect( tuples[1][:a] ).to eq( 3 )
@@ -260,7 +260,7 @@ describe PG::Result do
 			@conn.send_query( "SELECT generate_series(2,4)" )
 			expect{
 				@conn.get_result.stream_each_row.to_a
-			}.to raise_error(PG::InvalidResultStatus, /not in single row mode/)
+			}.to raise_error(YugabyteYSQL::InvalidResultStatus, /not in single row mode/)
 		end
 
 		it "complains when intersected with get_result" do
@@ -268,14 +268,14 @@ describe PG::Result do
 			@conn.set_single_row_mode
 			expect{
 				@conn.get_result.stream_each_row.each{ @conn.get_result }
-			}.to raise_error(PG::NoResultError, /no result received/)
+			}.to raise_error(YugabyteYSQL::NoResultError, /no result received/)
 		end
 
 		it "raises server errors" do
 			@conn.send_query( "SELECT 0/0" )
 			expect{
 				@conn.get_result.stream_each_row.to_a
-			}.to raise_error(PG::DivisionByZero)
+			}.to raise_error(YugabyteYSQL::DivisionByZero)
 		end
 
 		it "raises an error if result number of fields change" do
@@ -288,7 +288,7 @@ describe PG::Result do
 					@conn.send_query("SELECT 2,3");
 					@conn.set_single_row_mode
 				end
-			}.to raise_error(PG::InvalidChangeOfResultFields, /from 1 to 2 /)
+			}.to raise_error(YugabyteYSQL::InvalidChangeOfResultFields, /from 1 to 2 /)
 			expect( res.cleared? ).to be true
 		end
 
@@ -301,7 +301,7 @@ describe PG::Result do
 				@conn.get_result.stream_each_row do |row|
 					# No-op
 				end
-			}.to raise_error(PG::QueryCanceled, /statement timeout/)
+			}.to raise_error(YugabyteYSQL::QueryCanceled, /statement timeout/)
 		end
 
 		it "should deny streaming when frozen" do
@@ -323,30 +323,30 @@ describe PG::Result do
 		exception = nil
 		begin
 			@conn.exec( "SELECT * FROM nonexistant_table" )
-		rescue PG::Error => err
+		rescue YugabyteYSQL::Error => err
 			exception = err
 		end
 
 		result = exception.result
 
 		expect( result ).to be_a( described_class() )
-		expect( result.error_field(PG::PG_DIAG_SEVERITY) ).to eq( 'ERROR' )
-		expect( result.error_field(PG::PG_DIAG_SQLSTATE) ).to eq( '42P01' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_SEVERITY) ).to eq('ERROR' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_SQLSTATE) ).to eq('42P01' )
 		expect(
-			result.error_field(PG::PG_DIAG_MESSAGE_PRIMARY)
+			result.error_field(YugabyteYSQL::PG_DIAG_MESSAGE_PRIMARY)
 		).to eq( 'relation "nonexistant_table" does not exist' )
-		expect( result.error_field(PG::PG_DIAG_MESSAGE_DETAIL) ).to be_nil()
-		expect( result.error_field(PG::PG_DIAG_MESSAGE_HINT) ).to be_nil()
-		expect( result.error_field(PG::PG_DIAG_STATEMENT_POSITION) ).to eq( '15' )
-		expect( result.error_field(PG::PG_DIAG_INTERNAL_POSITION) ).to be_nil()
-		expect( result.error_field(PG::PG_DIAG_INTERNAL_QUERY) ).to be_nil()
-		expect( result.error_field(PG::PG_DIAG_CONTEXT) ).to be_nil()
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_MESSAGE_DETAIL) ).to be_nil()
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_MESSAGE_HINT) ).to be_nil()
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_STATEMENT_POSITION) ).to eq('15' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_INTERNAL_POSITION) ).to be_nil()
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_INTERNAL_QUERY) ).to be_nil()
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_CONTEXT) ).to be_nil()
 		expect(
-			result.error_field(PG::PG_DIAG_SOURCE_FILE)
+			result.error_field(YugabyteYSQL::PG_DIAG_SOURCE_FILE)
 		).to match( /parse_relation\.c$|namespace\.c$/ )
-		expect( result.error_field(PG::PG_DIAG_SOURCE_LINE) ).to match( /^\d+$/ )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_SOURCE_LINE) ).to match(/^\d+$/ )
 		expect(
-			result.error_field(PG::PG_DIAG_SOURCE_FUNCTION)
+			result.error_field(YugabyteYSQL::PG_DIAG_SOURCE_FUNCTION)
 		).to match( /^parserOpenTable$|^RangeVarGetRelid$/ )
 	end
 
@@ -354,11 +354,11 @@ describe PG::Result do
 		result = nil
 		begin
 			@conn.exec( "SELECT * FROM nonexistant_table" )
-		rescue PG::Error => err
+		rescue YugabyteYSQL::Error => err
 			result = err.result
 		end
 
-		expect( result.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED) ).to eq( 'ERROR' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_SEVERITY_NONLOCALIZED) ).to eq('ERROR' )
 	end
 
 	it "encapsulates database object names for integrity constraint violations" do
@@ -366,24 +366,24 @@ describe PG::Result do
 		exception = nil
 		begin
 			@conn.exec( "INSERT INTO integrity VALUES (NULL)" )
-		rescue PG::Error => err
+		rescue YugabyteYSQL::Error => err
 			exception = err
 		end
 		result = exception.result
 
-		expect( result.error_field(PG::PG_DIAG_SCHEMA_NAME) ).to eq( 'public' )
-		expect( result.error_field(PG::PG_DIAG_TABLE_NAME) ).to eq( 'integrity' )
-		expect( result.error_field(PG::PG_DIAG_COLUMN_NAME) ).to eq( 'id' )
-		expect( result.error_field(PG::PG_DIAG_DATATYPE_NAME) ).to be_nil
-		expect( result.error_field(PG::PG_DIAG_CONSTRAINT_NAME) ).to be_nil
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_SCHEMA_NAME) ).to eq('public' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_TABLE_NAME) ).to eq('integrity' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_COLUMN_NAME) ).to eq('id' )
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_DATATYPE_NAME) ).to be_nil
+		expect( result.error_field(YugabyteYSQL::PG_DIAG_CONSTRAINT_NAME) ).to be_nil
 	end
 
 	it "detects division by zero as SQLSTATE 22012" do
 		sqlstate = nil
 		begin
 			@conn.exec("SELECT 1/0")
-		rescue PG::Error => e
-			sqlstate = e.result.result_error_field( PG::PG_DIAG_SQLSTATE ).to_i
+		rescue YugabyteYSQL::Error => e
+			sqlstate = e.result.result_error_field(YugabyteYSQL::PG_DIAG_SQLSTATE ).to_i
 		end
 		expect( sqlstate ).to eq( 22012 )
 	end
@@ -399,15 +399,15 @@ describe PG::Result do
 		@conn.send_query("SELECT xyz")
 		res = @conn.get_result; @conn.get_result
 		# PQERRORS_TERSE should give a single line result
-		expect( res.verbose_error_message(PG::PQERRORS_TERSE, PG::PQSHOW_CONTEXT_ALWAYS) ).to match(/\A.*\n\z/)
+		expect( res.verbose_error_message(YugabyteYSQL::PQERRORS_TERSE, YugabyteYSQL::PQSHOW_CONTEXT_ALWAYS) ).to match(/\A.*\n\z/)
 		# PQERRORS_VERBOSE should give a multi line result
-		expect( res.result_verbose_error_message(PG::PQERRORS_VERBOSE, PG::PQSHOW_CONTEXT_NEVER) ).to match(/\n.*\n/)
+		expect( res.result_verbose_error_message(YugabyteYSQL::PQERRORS_VERBOSE, YugabyteYSQL::PQSHOW_CONTEXT_NEVER) ).to match(/\n.*\n/)
 	end
 
 	it "provides a verbose error message with SQLSTATE", :postgresql_12 do
 		@conn.send_query("SELECT xyz")
 		res = @conn.get_result; @conn.get_result
-		expect( res.verbose_error_message(PG::PQERRORS_SQLSTATE, PG::PQSHOW_CONTEXT_NEVER) ).to match(/42703/)
+		expect( res.verbose_error_message(YugabyteYSQL::PQERRORS_SQLSTATE, YugabyteYSQL::PQSHOW_CONTEXT_NEVER) ).to match(/42703/)
 	end
 
 	it "returns the same bytes in binary format that are sent in binary format" do
@@ -425,7 +425,7 @@ describe PG::Result do
 		binary_file = File.join(Dir.pwd, 'spec/data', 'random_binary_data')
 		bytes = File.open(binary_file, 'rb').read
 		@conn.exec("SET standard_conforming_strings=on")
-		res = @conn.exec_params("VALUES ('#{PG::Connection.escape_bytea(bytes)}'::bytea)", [], 1)
+		res = @conn.exec_params("VALUES ('#{YugabyteYSQL::Connection.escape_bytea(bytes)}'::bytea)", [], 1)
 		expect( res[0]['column1'] ).to eq( bytes )
 		expect( res.getvalue(0,0) ).to eq( bytes )
 		expect( res.values[0][0] ).to eq( bytes )
@@ -437,7 +437,7 @@ describe PG::Result do
 		bytes = File.open(binary_file, 'rb').read
 		res = @conn.exec_params('VALUES ($1::bytea)',
 			[ { :value => bytes, :format => 1 } ])
-		expect( PG::Connection.unescape_bytea(res[0]['column1']) ).to eq( bytes )
+		expect(YugabyteYSQL::Connection.unescape_bytea(res[0]['column1']) ).to eq(bytes )
 	end
 
 	it "returns the same bytes in text format that are sent as inline text" do
@@ -446,8 +446,8 @@ describe PG::Result do
 
 		out_bytes = nil
 		@conn.exec("SET standard_conforming_strings=on")
-		res = @conn.exec_params("VALUES ('#{PG::Connection.escape_bytea(in_bytes)}'::bytea)", [], 0)
-		out_bytes = PG::Connection.unescape_bytea(res[0]['column1'])
+		res = @conn.exec_params("VALUES ('#{YugabyteYSQL::Connection.escape_bytea(in_bytes)}'::bytea)", [], 0)
+		out_bytes = YugabyteYSQL::Connection.unescape_bytea(res[0]['column1'])
 		expect( out_bytes ).to eq( in_bytes )
 	end
 
@@ -496,10 +496,10 @@ describe PG::Result do
 
 	it "provides the result status" do
 		res = @conn.exec("SELECT 1")
-		expect( res.result_status ).to eq(PG::PGRES_TUPLES_OK)
+		expect( res.result_status ).to eq(YugabyteYSQL::PGRES_TUPLES_OK)
 
 		res = @conn.exec("")
-		expect( res.result_status ).to eq(PG::PGRES_EMPTY_QUERY)
+		expect( res.result_status ).to eq(YugabyteYSQL::PGRES_EMPTY_QUERY)
 	end
 
 	it "can retrieve number of fields" do
@@ -593,7 +593,7 @@ describe PG::Result do
 	   "column with no corresponding table" do
 		@conn.exec( 'CREATE TABLE ftabletest ( foo text )' )
 		res = @conn.exec( 'SELECT foo, LENGTH(foo) as length FROM ftabletest' )
-		expect( res.ftable(1) ).to eq( PG::INVALID_OID )
+		expect( res.ftable(1) ).to eq(YugabyteYSQL::INVALID_OID )
 	end
 
 	# PQftablecol
@@ -631,7 +631,7 @@ describe PG::Result do
 		res = @conn.get_result
 		expect {
 			res.check
-		}.to raise_error( PG::Error, /relation "nonexistant_table" does not exist/ )
+		}.to raise_error(YugabyteYSQL::Error, /relation "nonexistant_table" does not exist/ )
 	end
 
 	it "can return the values of a single field" do
@@ -654,8 +654,8 @@ describe PG::Result do
 
 	it "can return the values of a single vary lazy tuple" do
 		res = @conn.exec( "VALUES(1),(2)" )
-		expect( res.tuple(0) ).to be_kind_of( PG::Tuple )
-		expect( res.tuple(1) ).to be_kind_of( PG::Tuple )
+		expect( res.tuple(0) ).to be_kind_of(YugabyteYSQL::Tuple )
+		expect( res.tuple(1) ).to be_kind_of(YugabyteYSQL::Tuple )
 		expect{ res.tuple(2) }.to raise_error(IndexError)
 		expect{ res.tuple(-1) }.to raise_error(IndexError)
 		expect{ res.tuple("x") }.to raise_error(TypeError)
@@ -664,51 +664,51 @@ describe PG::Result do
 	it "raises a proper exception for a nonexistant table" do
 		expect {
 			@conn.exec( "SELECT * FROM nonexistant_table" )
-		}.to raise_error( PG::UndefinedTable, /relation "nonexistant_table" does not exist/ )
+		}.to raise_error(YugabyteYSQL::UndefinedTable, /relation "nonexistant_table" does not exist/ )
 	end
 
 	it "raises a more generic exception for an unknown SQLSTATE" do
-		old_error = PG::ERROR_CLASSES.delete('42P01')
+		old_error = YugabyteYSQL::ERROR_CLASSES.delete('42P01')
 		begin
 			expect {
 				@conn.exec( "SELECT * FROM nonexistant_table" )
 			}.to raise_error{|error|
-				expect( error ).to be_an_instance_of(PG::SyntaxErrorOrAccessRuleViolation)
+				expect( error ).to be_an_instance_of(YugabyteYSQL::SyntaxErrorOrAccessRuleViolation)
 				expect( error.to_s ).to match(/relation "nonexistant_table" does not exist/)
 			}
 		ensure
-			PG::ERROR_CLASSES['42P01'] = old_error
+			YugabyteYSQL::ERROR_CLASSES['42P01'] = old_error
 		end
 	end
 
 	it "raises a ServerError for an unknown SQLSTATE class" do
-		old_error1 = PG::ERROR_CLASSES.delete('42P01')
-		old_error2 = PG::ERROR_CLASSES.delete('42')
+		old_error1 = YugabyteYSQL::ERROR_CLASSES.delete('42P01')
+		old_error2 = YugabyteYSQL::ERROR_CLASSES.delete('42')
 		begin
 			expect {
 				@conn.exec( "SELECT * FROM nonexistant_table" )
 			}.to raise_error{|error|
-				expect( error ).to be_an_instance_of(PG::ServerError)
+				expect( error ).to be_an_instance_of(YugabyteYSQL::ServerError)
 				expect( error.to_s ).to match(/relation "nonexistant_table" does not exist/)
 			}
 		ensure
-			PG::ERROR_CLASSES['42P01'] = old_error1
-			PG::ERROR_CLASSES['42'] = old_error2
+			YugabyteYSQL::ERROR_CLASSES['42P01'] = old_error1
+			YugabyteYSQL::ERROR_CLASSES['42'] = old_error2
 		end
 	end
 
 	it "raises a proper exception for a nonexistant schema" do
 		expect {
 			@conn.exec( "DROP SCHEMA nonexistant_schema" )
-		}.to raise_error( PG::InvalidSchemaName, /schema "nonexistant_schema" does not exist/ )
+		}.to raise_error(YugabyteYSQL::InvalidSchemaName, /schema "nonexistant_schema" does not exist/ )
 	end
 
 	it "the raised result is nil in case of a connection error" do
-		c = PG::Connection.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
+		c = YugabyteYSQL::Connection.connect_start('127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
 		expect {
 			c.exec "select 1"
 		}.to raise_error {|error|
-			expect( error ).to be_an_instance_of(PG::UnableToSend)
+			expect( error ).to be_an_instance_of(YugabyteYSQL::UnableToSend)
 			expect( error.result ).to eq( nil )
 		}
 	end
@@ -736,36 +736,36 @@ describe PG::Result do
 	end
 
 	it "doesn't define #allocate" do
-		expect{ PG::Result.allocate }.to raise_error { |error|
+		expect{ YugabyteYSQL::Result.allocate }.to raise_error { |error|
 			expect( error ).to satisfy { |v| [NoMethodError, TypeError].include?(v.class) }
 		}
 	end
 
 	it "doesn't define #new" do
-		expect{ PG::Result.new }.to raise_error { |error|
+		expect{ YugabyteYSQL::Result.new }.to raise_error { |error|
 			expect( error ).to satisfy { |v| [NoMethodError, TypeError].include?(v.class) }
 		}
 	end
 
 	context 'result value conversions with TypeMapByColumn' do
-		let!(:textdec_int){ PG::TextDecoder::Integer.new name: 'INT4', oid: 23 }
-		let!(:textdec_float){ PG::TextDecoder::Float.new name: 'FLOAT4', oid: 700 }
+		let!(:textdec_int){ YugabyteYSQL::TextDecoder::Integer.new name: 'INT4', oid: 23 }
+		let!(:textdec_float){ YugabyteYSQL::TextDecoder::Float.new name: 'FLOAT4', oid: 700 }
 
 		it "should allow reading, assigning and disabling type conversions" do
 			res = @conn.exec( "SELECT 123" )
-			expect( res.type_map ).to be_kind_of(PG::TypeMapAllStrings)
-			res.type_map = PG::TypeMapByColumn.new [textdec_int]
-			expect( res.type_map ).to be_an_instance_of(PG::TypeMapByColumn)
+			expect( res.type_map ).to be_kind_of(YugabyteYSQL::TypeMapAllStrings)
+			res.type_map = YugabyteYSQL::TypeMapByColumn.new [textdec_int]
+			expect( res.type_map ).to be_an_instance_of(YugabyteYSQL::TypeMapByColumn)
 			expect( res.type_map.coders ).to eq( [textdec_int] )
-			res.type_map = PG::TypeMapByColumn.new [textdec_float]
+			res.type_map = YugabyteYSQL::TypeMapByColumn.new [textdec_float]
 			expect( res.type_map.coders ).to eq( [textdec_float] )
-			res.type_map = PG::TypeMapAllStrings.new
-			expect( res.type_map ).to be_kind_of(PG::TypeMapAllStrings)
+			res.type_map = YugabyteYSQL::TypeMapAllStrings.new
+			expect( res.type_map ).to be_kind_of(YugabyteYSQL::TypeMapAllStrings)
 		end
 
 		it "should be applied to all value retrieving methods" do
 			res = @conn.exec( "SELECT 123 as f" )
-			res.type_map = PG::TypeMapByColumn.new [textdec_int]
+			res.type_map = YugabyteYSQL::TypeMapByColumn.new [textdec_int]
 			expect( res.values ).to eq( [[123]] )
 			expect( res.getvalue(0,0) ).to eq( 123 )
 			expect( res[0] ).to eq( {'f' => 123 } )
@@ -778,7 +778,7 @@ describe PG::Result do
 		end
 
 		it "should be usable for several queries" do
-			colmap = PG::TypeMapByColumn.new [textdec_int]
+			colmap = YugabyteYSQL::TypeMapByColumn.new [textdec_int]
 			res = @conn.exec( "SELECT 123" )
 			res.type_map = colmap
 			expect( res.values ).to eq( [[123]] )

--- a/spec/pg/scheduler_spec.rb
+++ b/spec/pg/scheduler_spec.rb
@@ -52,7 +52,7 @@ context "with a Fiber scheduler", :scheduler do
 			q = Queue.new
 			3.times do
 				Fiber.schedule do
-					conn = PG.connect(@conninfo_gate)
+					conn = YugabyteYSQL.connect(@conninfo_gate)
 					conn.finish
 					q << true
 				end
@@ -64,12 +64,12 @@ context "with a Fiber scheduler", :scheduler do
 
 	it "connects using without host but envirinment variables", :postgresql_12, :unix_socket do
 		run_with_scheduler do
-			vars = PG::Connection.conninfo_parse(@conninfo_gate).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
+			vars = YugabyteYSQL::Connection.conninfo_parse(@conninfo_gate).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
 
 			tmpconn = with_env_vars(PGHOST: "scheduler-localhost", PGPORT: vars[:port], PGDATABASE: vars[:dbname], PGSSLMODE: vars[:sslmode]) do
-				PG.connect
+				YugabyteYSQL.connect
 			end
-			expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
+			expect( tmpconn.status ).to eq(YugabyteYSQL::CONNECTION_OK )
 			expect( tmpconn.host ).to eq( "scheduler-localhost" )
 			tmpconn.finish
 		end
@@ -78,7 +78,7 @@ context "with a Fiber scheduler", :scheduler do
 	it "can connect with DNS lookup", :scheduler_address_resolve do
 		run_with_scheduler do
 			conninfo = @conninfo_gate.gsub(/(^| )host=\w+/, " host=scheduler-localhost")
-			conn = PG.connect(conninfo)
+			conn = YugabyteYSQL.connect(conninfo)
 			opt = conn.conninfo.find { |info| info[:keyword] == 'host' }
 			expect( opt[:val] ).to start_with( 'scheduler-localhost' )
 			conn.finish
@@ -87,7 +87,7 @@ context "with a Fiber scheduler", :scheduler do
 
 	it "can reset the connection" do
 		run_with_scheduler do
-			conn = PG.connect(@conninfo_gate)
+			conn = YugabyteYSQL.connect(@conninfo_gate)
 			conn.exec("SET search_path TO test1")
 			expect( conn.exec("SHOW search_path").values ).to eq( [["test1"]] )
 			conn.reset
@@ -241,7 +241,7 @@ context "with a Fiber scheduler", :scheduler do
 				conn.cancel if notice =~ /foobar/
 			end
 			conn.send_query "do $$ BEGIN RAISE NOTICE 'foobar'; PERFORM pg_sleep(5); END; $$ LANGUAGE plpgsql;"
-			expect{ conn.get_last_result }.to raise_error(PG::QueryCanceled)
+			expect{ conn.get_last_result }.to raise_error(YugabyteYSQL::QueryCanceled)
 			expect( Time.now - start ).to be < 4.9
 		end
 	end
@@ -259,8 +259,8 @@ context "with a Fiber scheduler", :scheduler do
 		run_with_scheduler do |conn|
 			# ping doesn't trigger the scheduler, but runs in a second thread.
 			# This is why @conninfo is used instead of @conninfo_gate
-			ping = PG::Connection.ping(@conninfo)
-			expect( ping ).to eq( PG::PQPING_OK )
+			ping = YugabyteYSQL::Connection.ping(@conninfo)
+			expect( ping ).to eq(YugabyteYSQL::PQPING_OK )
 		end
 	end
 end

--- a/spec/pg/tuple_spec.rb
+++ b/spec/pg/tuple_spec.rb
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 require_relative '../helpers'
-require 'pg'
+require 'yugabyte_ysql'
 
-describe PG::Tuple do
-	let!(:typemap) { PG::BasicTypeMapForResults.new(@conn).freeze }
+describe YugabyteYSQL::Tuple do
+	let!(:typemap) { YugabyteYSQL::BasicTypeMapForResults.new(@conn).freeze }
 	let!(:result2x2) { @conn.exec( "VALUES(1, 'a'), (2, 'b')" ).freeze }
 	let!(:result2x2_writable) { @conn.exec( "VALUES(1, 'a'), (2, 'b')" ) }
 	let!(:result2x2sym) { @conn.exec( "VALUES(1, 'a'), (2, 'b')" ).field_names_as(:symbol).freeze }
@@ -26,7 +26,7 @@ describe PG::Tuple do
 	let!(:tuple2) { result2x3cast.tuple(0).freeze }
 	let!(:tuple2sym) { result2x3symcast.tuple(0).freeze }
 	let!(:tuple3) { str = Marshal.dump(result2x3cast.tuple(1).freeze); Marshal.load(str) }
-	let!(:tuple_empty) { PG::Tuple.new.freeze }
+	let!(:tuple_empty) { YugabyteYSQL::Tuple.new.freeze }
 
 	describe "[]" do
 		it "returns nil for invalid keys" do
@@ -79,14 +79,14 @@ describe PG::Tuple do
 
 		it "casts lazy and caches result" do
 			a = []
-			deco = Class.new(PG::SimpleDecoder) do
+			deco = Class.new(YugabyteYSQL::SimpleDecoder) do
 				define_method(:decode) do |*args|
 					a << args
 					args.last
 				end
 			end.new
 
-			result2x2_writable.map_types!(PG::TypeMapByColumn.new([deco, deco]))
+			result2x2_writable.map_types!(YugabyteYSQL::TypeMapByColumn.new([deco, deco]))
 			t = result2x2_writable.tuple(1)
 
 			# cast and cache at first call to [0]
@@ -323,9 +323,9 @@ describe PG::Tuple do
 			r.clear
 
 			# second column should fail
-			expect{ t[1] }.to raise_error(PG::Error)
-			expect{ t.fetch(1) }.to raise_error(PG::Error)
-			expect{ t.fetch("column2") }.to raise_error(PG::Error)
+			expect{ t[1] }.to raise_error(YugabyteYSQL::Error)
+			expect{ t.fetch(1) }.to raise_error(YugabyteYSQL::Error)
+			expect{ t.fetch("column2") }.to raise_error(YugabyteYSQL::Error)
 
 			# first column should succeed
 			expect( t[0] ).to eq( "1" )
@@ -333,7 +333,7 @@ describe PG::Tuple do
 			expect( t.fetch("column1") ).to eq( "1" )
 
 			# should fail due to the second column
-			expect{ t.values }.to raise_error(PG::Error)
+			expect{ t.values }.to raise_error(YugabyteYSQL::Error)
 		end
 	end
 end

--- a/spec/pg/type_map_by_column_spec.rb
+++ b/spec/pg/type_map_by_column_spec.rb
@@ -3,22 +3,22 @@
 
 require_relative '../helpers'
 
-require 'pg'
+require 'yugabyte_ysql'
 
 
-describe PG::TypeMapByColumn do
+describe YugabyteYSQL::TypeMapByColumn do
 
-	let!(:textenc_int){ PG::TextEncoder::Integer.new(name: 'INT4', oid: 23).freeze }
-	let!(:textdec_int){ PG::TextDecoder::Integer.new(name: 'INT4', oid: 23).freeze }
-	let!(:textenc_float){ PG::TextEncoder::Float.new(name: 'FLOAT4', oid: 700).freeze }
-	let!(:textdec_float){ PG::TextDecoder::Float.new(name: 'FLOAT4', oid: 700).freeze }
-	let!(:textenc_string){ PG::TextEncoder::String.new(name: 'TEXT', oid: 25).freeze }
-	let!(:textdec_string){ PG::TextDecoder::String.new(name: 'TEXT', oid: 25).freeze }
-	let!(:textdec_bytea){ PG::TextDecoder::Bytea.new(name: 'BYTEA', oid: 17).freeze }
-	let!(:binaryenc_bytea){ PG::BinaryEncoder::Bytea.new(name: 'BYTEA', oid: 17, format: 1).freeze }
-	let!(:binarydec_bytea){ PG::BinaryDecoder::Bytea.new(name: 'BYTEA', oid: 17, format: 1).freeze }
+	let!(:textenc_int){ YugabyteYSQL::TextEncoder::Integer.new(name: 'INT4', oid: 23).freeze }
+	let!(:textdec_int){ YugabyteYSQL::TextDecoder::Integer.new(name: 'INT4', oid: 23).freeze }
+	let!(:textenc_float){ YugabyteYSQL::TextEncoder::Float.new(name: 'FLOAT4', oid: 700).freeze }
+	let!(:textdec_float){ YugabyteYSQL::TextDecoder::Float.new(name: 'FLOAT4', oid: 700).freeze }
+	let!(:textenc_string){ YugabyteYSQL::TextEncoder::String.new(name: 'TEXT', oid: 25).freeze }
+	let!(:textdec_string){ YugabyteYSQL::TextDecoder::String.new(name: 'TEXT', oid: 25).freeze }
+	let!(:textdec_bytea){ YugabyteYSQL::TextDecoder::Bytea.new(name: 'BYTEA', oid: 17).freeze }
+	let!(:binaryenc_bytea){ YugabyteYSQL::BinaryEncoder::Bytea.new(name: 'BYTEA', oid: 17, format: 1).freeze }
+	let!(:binarydec_bytea){ YugabyteYSQL::BinaryDecoder::Bytea.new(name: 'BYTEA', oid: 17, format: 1).freeze }
 	let!(:pass_through_type) do
-		type = Class.new(PG::SimpleDecoder) do
+		type = Class.new(YugabyteYSQL::SimpleDecoder) do
 			def decode(*v)
 				v
 			end
@@ -30,27 +30,27 @@ describe PG::TypeMapByColumn do
 	end
 
 	it "should deny changes when frozen" do
-		tm = PG::TypeMapByColumn.new([]).freeze
-		expect{ tm.default_type_map = PG::TypeMapByClass.new }.to raise_error(FrozenError)
-		expect{ tm.with_default_type_map(PG::TypeMapByClass.new) }.to raise_error(FrozenError)
+		tm = YugabyteYSQL::TypeMapByColumn.new([]).freeze
+		expect{ tm.default_type_map = YugabyteYSQL::TypeMapByClass.new }.to raise_error(FrozenError)
+		expect{ tm.with_default_type_map(YugabyteYSQL::TypeMapByClass.new) }.to raise_error(FrozenError)
 	end
 
 	it "should be shareable for Ractor", :ractor do
-		tm = PG::TypeMapByColumn.new([pass_through_type]).freeze
+		tm = YugabyteYSQL::TypeMapByColumn.new([pass_through_type]).freeze
 		Ractor.make_shareable(tm)
 	end
 
 	it "should give account about memory usage" do
-		tm = PG::TypeMapByColumn.new( [] ).freeze
+		tm = YugabyteYSQL::TypeMapByColumn.new([] ).freeze
 		size0 =  ObjectSpace.memsize_of(tm)
 		expect( size0 ).to be > DATA_OBJ_MEMSIZE
 
-		tm = PG::TypeMapByColumn.new( [textenc_float, nil, textenc_int] ).freeze
+		tm = YugabyteYSQL::TypeMapByColumn.new([textenc_float, nil, textenc_int] ).freeze
 		expect( ObjectSpace.memsize_of(tm) ).to be > size0
 	end
 
 	it "should retrieve it's conversions" do
-		cm = PG::TypeMapByColumn.new( [textdec_int, textenc_string, textdec_float, pass_through_type, nil] ).freeze
+		cm = YugabyteYSQL::TypeMapByColumn.new([textdec_int, textenc_string, textdec_float, pass_through_type, nil] ).freeze
 		expect( cm.coders ).to eq( [
 			textdec_int,
 			textenc_string,
@@ -61,12 +61,12 @@ describe PG::TypeMapByColumn do
 	end
 
 	it "should respond to inspect" do
-		cm = PG::TypeMapByColumn.new( [textdec_int, textenc_string, textdec_float, pass_through_type, PG::TextEncoder::Float.new, nil] ).freeze
+		cm = YugabyteYSQL::TypeMapByColumn.new([textdec_int, textenc_string, textdec_float, pass_through_type, YugabyteYSQL::TextEncoder::Float.new, nil] ).freeze
 		expect( cm.inspect ).to eq( "#<PG::TypeMapByColumn INT4:TD TEXT:TE FLOAT4:TD pass_through:BD PG::TextEncoder::Float:TE nil>" )
 	end
 
 	it "should retrieve it's oids" do
-		cm = PG::TypeMapByColumn.new( [textdec_int, textdec_string, textdec_float, pass_through_type, nil] ).freeze
+		cm = YugabyteYSQL::TypeMapByColumn.new([textdec_int, textdec_string, textdec_float, pass_through_type, nil] ).freeze
 		expect( cm.oids ).to eq( [23, 25, 700, 123456, nil] )
 	end
 
@@ -74,7 +74,7 @@ describe PG::TypeMapByColumn do
 		# PG::TypeMapByColumn is not initialized in allocate function, like other
 		# type maps, but in #initialize. So it might be not called by derived classes.
 
-		not_init = Class.new(PG::TypeMapByColumn) do
+		not_init = Class.new(YugabyteYSQL::TypeMapByColumn) do
 			def initialize
 				# no super call
 			end
@@ -86,7 +86,7 @@ describe PG::TypeMapByColumn do
 		expect{ res.type_map = not_init }.to raise_error(NotImplementedError)
 
 		@conn.copy_data("COPY (SELECT 1) TO STDOUT") do
-			decoder = PG::TextDecoder::CopyRow.new(type_map: not_init)
+			decoder = YugabyteYSQL::TextDecoder::CopyRow.new(type_map: not_init)
 			expect{ @conn.get_copy_data(false, decoder) }.to raise_error(NotImplementedError)
 			@conn.get_copy_data
 		end
@@ -98,7 +98,7 @@ describe PG::TypeMapByColumn do
 	#
 
 	it "should encode integer params" do
-		col_map = PG::TypeMapByColumn.new( [textenc_int]*3 ).freeze
+		col_map = YugabyteYSQL::TypeMapByColumn.new([textenc_int]*3 ).freeze
 		res = @conn.exec_params( "SELECT $1, $2, $3", [ 0, nil, "-999" ], 0, col_map )
 		expect( res.values ).to eq( [
 				[ "0", nil, "-999" ],
@@ -107,9 +107,9 @@ describe PG::TypeMapByColumn do
 
 	it "should encode bytea params" do
 		data = "'\u001F\\"
-		col_map = PG::TypeMapByColumn.new( [binaryenc_bytea]*2 ).freeze
+		col_map = YugabyteYSQL::TypeMapByColumn.new([binaryenc_bytea]*2 ).freeze
 		res = @conn.exec_params( "SELECT $1, $2", [ data, nil ], 0, col_map )
-		res.type_map = PG::TypeMapByColumn.new( [textdec_bytea]*2 )
+		res.type_map = YugabyteYSQL::TypeMapByColumn.new([textdec_bytea]*2 )
 		expect( res.values ).to eq( [
 				[ data, nil ],
 		] )
@@ -117,7 +117,7 @@ describe PG::TypeMapByColumn do
 
 
 	it "should allow hash form parameters for default encoder" do
-		col_map = PG::TypeMapByColumn.new( [nil, nil] ).freeze
+		col_map = YugabyteYSQL::TypeMapByColumn.new([nil, nil] ).freeze
 		hash_param_bin = { value: ["00ff"].pack("H*"), type: 17, format: 1 }
 		hash_param_nil = { value: nil, type: 17, format: 1 }
 		res = @conn.exec_params( "SELECT $1, $2",
@@ -127,7 +127,7 @@ describe PG::TypeMapByColumn do
 	end
 
 	it "should convert hash form parameters to string when using string encoders" do
-		col_map = PG::TypeMapByColumn.new( [textenc_string, textenc_string] ).freeze
+		col_map = YugabyteYSQL::TypeMapByColumn.new([textenc_string, textenc_string] ).freeze
 		hash_param_bin = { value: ["00ff"].pack("H*"), type: 17, format: 1 }
 		hash_param_nil = { value: nil, type: 17, format: 1 }
 		res = @conn.exec_params( "SELECT $1::text, $2::text",
@@ -137,22 +137,22 @@ describe PG::TypeMapByColumn do
 
 	it "shouldn't allow param mappings with different number of fields" do
 		expect{
-			@conn.exec_params( "SELECT $1", [ 123 ], 0, PG::TypeMapByColumn.new([]).freeze )
+			@conn.exec_params("SELECT $1", [ 123 ], 0, YugabyteYSQL::TypeMapByColumn.new([]).freeze )
 		}.to raise_error(ArgumentError, /mapped columns/)
 	end
 
 	it "should verify the default type map for query params as well" do
-		tm1 = PG::TypeMapByColumn.new([]).freeze
+		tm1 = YugabyteYSQL::TypeMapByColumn.new([]).freeze
 		expect{
-			@conn.exec_params( "SELECT $1", [ 123 ], 0, PG::TypeMapByColumn.new([nil]).with_default_type_map(tm1) )
+			@conn.exec_params("SELECT $1", [ 123 ], 0, YugabyteYSQL::TypeMapByColumn.new([nil]).with_default_type_map(tm1) )
 		}.to raise_error(ArgumentError, /mapped columns/)
 	end
 
 	it "forwards query param conversions to the #default_type_map" do
-		tm1 = PG::TypeMapByClass.new
-		tm1[Integer] = PG::TextEncoder::Integer.new name: 'INT2', oid: 21
+		tm1 = YugabyteYSQL::TypeMapByClass.new
+		tm1[Integer] = YugabyteYSQL::TextEncoder::Integer.new name: 'INT2', oid: 21
 
-		tm2 = PG::TypeMapByColumn.new( [textenc_int, nil, nil] ).with_default_type_map( tm1 ).freeze
+		tm2 = YugabyteYSQL::TypeMapByColumn.new([textenc_int, nil, nil] ).with_default_type_map(tm1 ).freeze
 		res = @conn.exec_params( "SELECT $1, $2, $3::TEXT", [1, 2, :abc], 0, tm2 )
 
 		expect( res.ftype(0) ).to eq( 23 ) # tm2
@@ -164,7 +164,7 @@ describe PG::TypeMapByColumn do
 	# Decoding Examples
 	#
 
-	class Exception_in_decode < PG::SimpleDecoder
+	class Exception_in_decode < YugabyteYSQL::SimpleDecoder
 		def decode(res, tuple, field)
 			raise "no type decoder defined for tuple #{tuple} field #{field}"
 		end
@@ -173,36 +173,36 @@ describe PG::TypeMapByColumn do
 	it "should raise an error from decode method of type converter" do
 		res = @conn.exec( "SELECT now()" )
 		types = Array.new( res.nfields, Exception_in_decode.new )
-		res.type_map = PG::TypeMapByColumn.new( types ).freeze
+		res.type_map = YugabyteYSQL::TypeMapByColumn.new(types ).freeze
 		expect{ res.values }.to raise_error(/no type decoder defined/)
 	end
 
 	it "should raise an error for invalid params" do
-		expect{ PG::TypeMapByColumn.new( :WrongType ) }.to raise_error(TypeError, /wrong argument type/)
-		expect{ PG::TypeMapByColumn.new( [123] ) }.to raise_error(TypeError, /wrong argument type (Integer|Fixnum)/)
+		expect{ YugabyteYSQL::TypeMapByColumn.new(:WrongType ) }.to raise_error(TypeError, /wrong argument type/)
+		expect{ YugabyteYSQL::TypeMapByColumn.new([123] ) }.to raise_error(TypeError, /wrong argument type (Integer|Fixnum)/)
 	end
 
 	it "shouldn't allow result mappings with different number of fields" do
 		res = @conn.exec( "SELECT 1" )
-		expect{ res.type_map = PG::TypeMapByColumn.new([]) }.to raise_error(ArgumentError, /mapped columns/)
+		expect{ res.type_map = YugabyteYSQL::TypeMapByColumn.new([]) }.to raise_error(ArgumentError, /mapped columns/)
 	end
 
 	it "should verify the default type map for result values as well" do
 		res = @conn.exec( "SELECT 1" )
-		tm1 = PG::TypeMapByColumn.new([]).freeze
+		tm1 = YugabyteYSQL::TypeMapByColumn.new([]).freeze
 		expect{
-			res.type_map = PG::TypeMapByColumn.new([nil]).with_default_type_map(tm1)
+			res.type_map = YugabyteYSQL::TypeMapByColumn.new([nil]).with_default_type_map(tm1)
 		}.to raise_error(ArgumentError, /mapped columns/)
 	end
 
 	it "forwards result value conversions to a TypeMapByOid as #default_type_map" do
 		# One run with implicit built TypeMapByColumn and another with online lookup
 		[0, 10].each do |max_rows|
-			tm1 = PG::TypeMapByOid.new
-			tm1.add_coder PG::TextDecoder::Integer.new name: 'INT2', oid: 21
+			tm1 = YugabyteYSQL::TypeMapByOid.new
+			tm1.add_coder YugabyteYSQL::TextDecoder::Integer.new name: 'INT2', oid: 21
 			tm1.max_rows_for_online_lookup = max_rows
 
-			tm2 = PG::TypeMapByColumn.new( [textdec_int, nil, nil] ).with_default_type_map( tm1 ).freeze
+			tm2 = YugabyteYSQL::TypeMapByColumn.new([textdec_int, nil, nil] ).with_default_type_map(tm1 ).freeze
 			res = @conn.exec( "SELECT '1'::INT4, '2'::INT2, '3'::INT8" ).map_types!( tm2 )
 
 			expect( res.getvalue(0,0) ).to eq( 1 ) # tm2
@@ -212,8 +212,8 @@ describe PG::TypeMapByColumn do
 	end
 
 	it "get_copy_data returns string with encoding" do
-		tm1 = PG::TypeMapByColumn.new( [textdec_string, textdec_bytea] ).freeze
-		decoder = PG::TextDecoder::CopyRow.new(type_map: tm1)
+		tm1 = YugabyteYSQL::TypeMapByColumn.new([textdec_string, textdec_bytea] ).freeze
+		decoder = YugabyteYSQL::TextDecoder::CopyRow.new(type_map: tm1)
 		@conn.copy_data("COPY (SELECT 'Ä', 'Ö') TO STDOUT", decoder) do
 			res = @conn.get_copy_data
 			expect( res ).to eq( ['Ä', 'Ö'.b] )
@@ -224,9 +224,9 @@ describe PG::TypeMapByColumn do
 	end
 
 	it "forwards get_copy_data conversions to another TypeMapByColumn as #default_type_map" do
-		tm1 = PG::TypeMapByColumn.new( [textdec_int, nil, nil] ).freeze
-		tm2 = PG::TypeMapByColumn.new( [nil, textdec_int, nil] ).with_default_type_map( tm1 ).freeze
-		decoder = PG::TextDecoder::CopyRow.new(type_map: tm2)
+		tm1 = YugabyteYSQL::TypeMapByColumn.new([textdec_int, nil, nil] ).freeze
+		tm2 = YugabyteYSQL::TypeMapByColumn.new([nil, textdec_int, nil] ).with_default_type_map(tm1 ).freeze
+		decoder = YugabyteYSQL::TextDecoder::CopyRow.new(type_map: tm2)
 		@conn.copy_data("COPY (SELECT 1, 2, 3) TO STDOUT", decoder) do
 			expect( @conn.get_copy_data ).to eq( [1, 2, '3'] )
 			@conn.get_copy_data
@@ -235,9 +235,9 @@ describe PG::TypeMapByColumn do
 
 	it "will deny copy queries with different column count" do
 		[[2, 2], [2, 3], [3, 2]].each do |cols1, cols2|
-			tm1 = PG::TypeMapByColumn.new( [textdec_int, nil, nil][0, cols1] ).freeze
-			tm2 = PG::TypeMapByColumn.new( [nil, textdec_int, nil][0, cols2] ).with_default_type_map( tm1 ).freeze
-			decoder = PG::TextDecoder::CopyRow.new(type_map: tm2)
+			tm1 = YugabyteYSQL::TypeMapByColumn.new([textdec_int, nil, nil][0, cols1] ).freeze
+			tm2 = YugabyteYSQL::TypeMapByColumn.new([nil, textdec_int, nil][0, cols2] ).with_default_type_map(tm1 ).freeze
+			decoder = YugabyteYSQL::TextDecoder::CopyRow.new(type_map: tm2)
 			@conn.copy_data("COPY (SELECT 1, 2, 3) TO STDOUT", decoder) do
 				expect{ @conn.get_copy_data }.to raise_error(ArgumentError, /number of copy fields/)
 				@conn.get_copy_data
@@ -251,7 +251,7 @@ describe PG::TypeMapByColumn do
 
 	it "should allow mixed type conversions" do
 		res = @conn.exec( "SELECT 1, 'a', 2.0::FLOAT, '2013-06-30'::DATE, 3" )
-		res.type_map = PG::TypeMapByColumn.new( [textdec_int, textdec_string, textdec_float, pass_through_type, nil] ).freeze
+		res.type_map = YugabyteYSQL::TypeMapByColumn.new([textdec_int, textdec_string, textdec_float, pass_through_type, nil] ).freeze
 		expect( res.values ).to eq( [[1, 'a', 2.0, ['2013-06-30', 0, 3], '3' ]] )
 	end
 

--- a/spec/pg/type_map_spec.rb
+++ b/spec/pg/type_map_spec.rb
@@ -3,11 +3,11 @@
 
 require_relative '../helpers'
 
-require 'pg'
+require 'yugabyte_ysql'
 
 
-describe PG::TypeMap do
-	let!(:tm){ PG::TypeMap.new.freeze }
+describe YugabyteYSQL::TypeMap do
+	let!(:tm){ YugabyteYSQL::TypeMap.new.freeze }
 
 	it "should give account about memory usage" do
 		expect( ObjectSpace.memsize_of(tm) ).to be > DATA_OBJ_MEMSIZE

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -1,51 +1,51 @@
 # -*- rspec -*-
 # encoding: utf-8
 
-require 'pg'
+require 'yugabyte_ysql'
 require 'time'
 
 
 describe "PG::Type derivations" do
-	let!(:textenc_int) { PG::TextEncoder::Integer.new name: 'Integer', oid: 23 }
-	let!(:textdec_int) { PG::TextDecoder::Integer.new name: 'Integer', oid: 23 }
-	let!(:textenc_boolean) { PG::TextEncoder::Boolean.new }
-	let!(:textdec_boolean) { PG::TextDecoder::Boolean.new }
-	let!(:textenc_float) { PG::TextEncoder::Float.new }
-	let!(:textdec_float) { PG::TextDecoder::Float.new }
+	let!(:textenc_int) { YugabyteYSQL::TextEncoder::Integer.new name: 'Integer', oid: 23 }
+	let!(:textdec_int) { YugabyteYSQL::TextDecoder::Integer.new name: 'Integer', oid: 23 }
+	let!(:textenc_boolean) { YugabyteYSQL::TextEncoder::Boolean.new }
+	let!(:textdec_boolean) { YugabyteYSQL::TextDecoder::Boolean.new }
+	let!(:textenc_float) { YugabyteYSQL::TextEncoder::Float.new }
+	let!(:textdec_float) { YugabyteYSQL::TextDecoder::Float.new }
 	let!(:textenc_numeric) do
 		begin
-			PG::TextEncoder::Numeric.new
+			YugabyteYSQL::TextEncoder::Numeric.new
 		rescue LoadError
 		end
 	end
-	let!(:textenc_string) { PG::TextEncoder::String.new }
-	let!(:textdec_string) { PG::TextDecoder::String.new }
-	let!(:textenc_timestamp) { PG::TextEncoder::TimestampWithoutTimeZone.new }
-	let!(:textdec_timestamp) { PG::TextDecoder::TimestampWithoutTimeZone.new }
-	let!(:textenc_timestamputc) { PG::TextEncoder::TimestampUtc.new }
-	let!(:textdec_timestamputc) { PG::TextDecoder::TimestampUtc.new }
-	let!(:textdec_timestampul) { PG::TextDecoder::TimestampUtcToLocal.new }
-	let!(:textenc_timestamptz) { PG::TextEncoder::TimestampWithTimeZone.new }
-	let!(:textdec_timestamptz) { PG::TextDecoder::TimestampWithTimeZone.new }
-	let!(:textenc_bytea) { PG::TextEncoder::Bytea.new }
-	let!(:textdec_bytea) { PG::TextDecoder::Bytea.new }
-	let!(:binaryenc_int2) { PG::BinaryEncoder::Int2.new }
-	let!(:binaryenc_int4) { PG::BinaryEncoder::Int4.new }
-	let!(:binaryenc_int8) { PG::BinaryEncoder::Int8.new }
-	let!(:binarydec_string) { PG::BinaryDecoder::String.new }
-	let!(:binarydec_integer) { PG::BinaryDecoder::Integer.new }
-	let!(:binaryenc_timestamputc) { PG::BinaryEncoder::TimestampUtc.new }
-	let!(:binaryenc_timestamplocal) { PG::BinaryEncoder::TimestampLocal.new }
+	let!(:textenc_string) { YugabyteYSQL::TextEncoder::String.new }
+	let!(:textdec_string) { YugabyteYSQL::TextDecoder::String.new }
+	let!(:textenc_timestamp) { YugabyteYSQL::TextEncoder::TimestampWithoutTimeZone.new }
+	let!(:textdec_timestamp) { YugabyteYSQL::TextDecoder::TimestampWithoutTimeZone.new }
+	let!(:textenc_timestamputc) { YugabyteYSQL::TextEncoder::TimestampUtc.new }
+	let!(:textdec_timestamputc) { YugabyteYSQL::TextDecoder::TimestampUtc.new }
+	let!(:textdec_timestampul) { YugabyteYSQL::TextDecoder::TimestampUtcToLocal.new }
+	let!(:textenc_timestamptz) { YugabyteYSQL::TextEncoder::TimestampWithTimeZone.new }
+	let!(:textdec_timestamptz) { YugabyteYSQL::TextDecoder::TimestampWithTimeZone.new }
+	let!(:textenc_bytea) { YugabyteYSQL::TextEncoder::Bytea.new }
+	let!(:textdec_bytea) { YugabyteYSQL::TextDecoder::Bytea.new }
+	let!(:binaryenc_int2) { YugabyteYSQL::BinaryEncoder::Int2.new }
+	let!(:binaryenc_int4) { YugabyteYSQL::BinaryEncoder::Int4.new }
+	let!(:binaryenc_int8) { YugabyteYSQL::BinaryEncoder::Int8.new }
+	let!(:binarydec_string) { YugabyteYSQL::BinaryDecoder::String.new }
+	let!(:binarydec_integer) { YugabyteYSQL::BinaryDecoder::Integer.new }
+	let!(:binaryenc_timestamputc) { YugabyteYSQL::BinaryEncoder::TimestampUtc.new }
+	let!(:binaryenc_timestamplocal) { YugabyteYSQL::BinaryEncoder::TimestampLocal.new }
 
 	let!(:intenc_incrementer) do
-		Class.new(PG::SimpleEncoder) do
+		Class.new(YugabyteYSQL::SimpleEncoder) do
 			def encode(value)
 				(value.to_i + 1).to_s + " "
 			end
 		end.new
 	end
 	let!(:intdec_incrementer) do
-		Class.new(PG::SimpleDecoder) do
+		Class.new(YugabyteYSQL::SimpleDecoder) do
 			def decode(string, tuple=nil, field=nil)
 				string.to_i+1
 			end
@@ -53,7 +53,7 @@ describe "PG::Type derivations" do
 	end
 
 	let!(:intenc_incrementer_with_encoding) do
-		Class.new(PG::SimpleEncoder) do
+		Class.new(YugabyteYSQL::SimpleEncoder) do
 			def encode(value, encoding)
 				r = (value.to_i + 1).to_s + " #{encoding}"
 				r.encode!(encoding)
@@ -61,7 +61,7 @@ describe "PG::Type derivations" do
 		end.new
 	end
 	let!(:intenc_incrementer_with_int_result) do
-		Class.new(PG::SimpleEncoder) do
+		Class.new(YugabyteYSQL::SimpleEncoder) do
 			def encode(value)
 				value.to_i+1
 			end
@@ -69,10 +69,10 @@ describe "PG::Type derivations" do
 	end
 
 	it "shouldn't be possible to build a PG::Type directly" do
-		expect{ PG::Coder.new }.to raise_error(TypeError, /cannot/)
+		expect{ YugabyteYSQL::Coder.new }.to raise_error(TypeError, /cannot/)
 	end
 
-	describe PG::SimpleCoder do
+	describe YugabyteYSQL::SimpleCoder do
 		describe '#decode' do
 			it "should offer decode method with tuple/field" do
 				res = textdec_int.decode("123", 1, 1)
@@ -233,19 +233,19 @@ describe "PG::Type derivations" do
 
 			context 'identifier quotation' do
 				it 'should build an array out of an quoted identifier string' do
-					quoted_type = PG::TextDecoder::Identifier.new
+					quoted_type = YugabyteYSQL::TextDecoder::Identifier.new
 					expect( quoted_type.decode(%["A.".".B"]) ).to eq( ["A.", ".B"] )
 					expect( quoted_type.decode(%["'A"".""B'"]) ).to eq( ['\'A"."B\''] )
 				end
 
 				it 'should split unquoted identifier string' do
-					quoted_type = PG::TextDecoder::Identifier.new
+					quoted_type = YugabyteYSQL::TextDecoder::Identifier.new
 					expect( quoted_type.decode(%[a.b]) ).to eq( ['a','b'] )
 					expect( quoted_type.decode(%[a]) ).to eq( ['a'] )
 				end
 
 				it 'should split identifier string with correct character encoding' do
-					quoted_type = PG::TextDecoder::Identifier.new
+					quoted_type = YugabyteYSQL::TextDecoder::Identifier.new
 					v = quoted_type.decode(%[Héllo].encode("iso-8859-1")).first
 					expect( v.encoding ).to eq( Encoding::ISO_8859_1 )
 					expect( v ).to eq( %[Héllo].encode(Encoding::ISO_8859_1) )
@@ -427,7 +427,7 @@ describe "PG::Type derivations" do
 
 			context 'identifier quotation' do
 				it 'should quote and escape identifier' do
-					quoted_type = PG::TextEncoder::Identifier.new
+					quoted_type = YugabyteYSQL::TextEncoder::Identifier.new
 					expect( quoted_type.encode(['schema','table','col']) ).to eq( %["schema"."table"."col"] )
 					expect( quoted_type.encode(['A.','.B']) ).to eq( %["A.".".B"] )
 					expect( quoted_type.encode(%['A"."B']) ).to eq( %["'A"".""B'"] )
@@ -435,14 +435,14 @@ describe "PG::Type derivations" do
 				end
 
 				it 'should quote identifiers with correct character encoding' do
-					quoted_type = PG::TextEncoder::Identifier.new
+					quoted_type = YugabyteYSQL::TextEncoder::Identifier.new
 					v = quoted_type.encode(['Héllo'], "iso-8859-1")
 					expect( v ).to eq( %["Héllo"].encode(Encoding::ISO_8859_1) )
 					expect( v.encoding ).to eq( Encoding::ISO_8859_1 )
 				end
 
 				it "will raise a TypeError for invalid arguments to quote_ident" do
-					quoted_type = PG::TextEncoder::Identifier.new
+					quoted_type = YugabyteYSQL::TextEncoder::Identifier.new
 					expect{ quoted_type.encode( [nil] ) }.to raise_error(TypeError)
 					expect{ quoted_type.encode( [['a']] ) }.to raise_error(TypeError)
 				end
@@ -492,29 +492,29 @@ describe "PG::Type derivations" do
 		end
 
 		it "should have reasonable default values" do
-			t = PG::TextEncoder::String.new
+			t = YugabyteYSQL::TextEncoder::String.new
 			expect( t.format ).to eq( 0 )
 			expect( t.oid ).to eq( 0 )
 			expect( t.name ).to be_nil
 
-			t = PG::BinaryEncoder::Int4.new
+			t = YugabyteYSQL::BinaryEncoder::Int4.new
 			expect( t.format ).to eq( 1 )
 			expect( t.oid ).to eq( 0 )
 			expect( t.name ).to be_nil
 
-			t = PG::TextDecoder::String.new
+			t = YugabyteYSQL::TextDecoder::String.new
 			expect( t.format ).to eq( 0 )
 			expect( t.oid ).to eq( 0 )
 			expect( t.name ).to be_nil
 
-			t = PG::BinaryDecoder::String.new
+			t = YugabyteYSQL::BinaryDecoder::String.new
 			expect( t.format ).to eq( 1 )
 			expect( t.oid ).to eq( 0 )
 			expect( t.name ).to be_nil
 		end
 
 		it "should overwrite default values as kwargs" do
-			t = PG::BinaryEncoder::Int4.new(format: 0)
+			t = YugabyteYSQL::BinaryEncoder::Int4.new(format: 0)
 			expect( t.format ).to eq( 0 )
 		end
 
@@ -538,72 +538,72 @@ describe "PG::Type derivations" do
 		it "should overwrite default format" do
 			t = nil
 			expect_deprecated_coder_init do
-				t = PG::BinaryEncoder::Int4.new({format: 0})
+				t = YugabyteYSQL::BinaryEncoder::Int4.new({ format: 0})
 			end
 			expect( t.format ).to eq( 0 )
 
-			t = PG::BinaryEncoder::Int4.new(format: 0)
+			t = YugabyteYSQL::BinaryEncoder::Int4.new(format: 0)
 			expect( t.format ).to eq( 0 )
 		end
 
 		it "should take hash argument" do
 			t = nil
-			expect_deprecated_coder_init { t = PG::TextEncoder::Integer.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::TextEncoder::Integer.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::BinaryEncoder::Int4.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::BinaryEncoder::Int4.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::BinaryDecoder::TimestampUtc.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::BinaryDecoder::TimestampUtc.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::BinaryDecoder::TimestampUtcToLocal.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::BinaryDecoder::TimestampUtcToLocal.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::BinaryDecoder::TimestampLocal.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::BinaryDecoder::TimestampLocal.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::BinaryEncoder::TimestampUtc.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::BinaryEncoder::TimestampUtc.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::BinaryEncoder::TimestampLocal.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::BinaryEncoder::TimestampLocal.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampUtc.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::TextDecoder::TimestampUtc.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampUtcToLocal.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::TextDecoder::TimestampUtcToLocal.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampLocal.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::TextDecoder::TimestampLocal.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampWithoutTimeZone.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::TextDecoder::TimestampWithoutTimeZone.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampWithTimeZone.new({name: "abcä"}) }
+			expect_deprecated_coder_init { t = YugabyteYSQL::TextDecoder::TimestampWithTimeZone.new({ name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
 		end
 
 		it "shouldn't overwrite timestamp flags" do
-			t = PG::TextDecoder::TimestampUtc.new({flags: PG::Coder::TIMESTAMP_DB_LOCAL})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC )
-			t = PG::TextDecoder::TimestampUtcToLocal.new({flags: PG::Coder::TIMESTAMP_APP_UTC})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL )
-			t = PG::TextDecoder::TimestampLocal.new({flags: PG::Coder::TIMESTAMP_DB_UTC})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL )
+			t = YugabyteYSQL::TextDecoder::TimestampUtc.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_UTC )
+			t = YugabyteYSQL::TextDecoder::TimestampUtcToLocal.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_APP_UTC})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL )
+			t = YugabyteYSQL::TextDecoder::TimestampLocal.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL )
 
-			t = PG::BinaryDecoder::TimestampUtc.new({flags: PG::Coder::TIMESTAMP_DB_LOCAL})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC )
-			t = PG::BinaryDecoder::TimestampUtcToLocal.new({flags: PG::Coder::TIMESTAMP_APP_UTC})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL )
-			t = PG::BinaryDecoder::TimestampLocal.new({flags: PG::Coder::TIMESTAMP_DB_UTC})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL )
+			t = YugabyteYSQL::BinaryDecoder::TimestampUtc.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_UTC )
+			t = YugabyteYSQL::BinaryDecoder::TimestampUtcToLocal.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_APP_UTC})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_UTC | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL )
+			t = YugabyteYSQL::BinaryDecoder::TimestampLocal.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_DB_UTC})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL | YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL )
 
-			t = PG::BinaryEncoder::TimestampUtc.new({flags: PG::Coder::TIMESTAMP_DB_LOCAL})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC )
-			t = PG::BinaryEncoder::TimestampLocal.new({flags: PG::Coder::TIMESTAMP_APP_LOCAL})
-			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_LOCAL )
+			t = YugabyteYSQL::BinaryEncoder::TimestampUtc.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_UTC )
+			t = YugabyteYSQL::BinaryEncoder::TimestampLocal.new({ flags: YugabyteYSQL::Coder::TIMESTAMP_APP_LOCAL})
+			expect( t.flags ).to eq(YugabyteYSQL::Coder::TIMESTAMP_DB_LOCAL )
 		end
 
 		it "should deny changes when frozen" do
-			t = PG::TextEncoder::String.new.freeze
+			t = YugabyteYSQL::TextEncoder::String.new.freeze
 			expect{ t.format = 1 }.to raise_error(FrozenError)
 			expect{ t.oid = 0  }.to raise_error(FrozenError)
 			expect{ t.name = "x" }.to raise_error(FrozenError)
 		end
 
 		it "should be shareable for Ractor", :ractor do
-			t = PG::TextEncoder::String.new.freeze
+			t = YugabyteYSQL::TextEncoder::String.new.freeze
 			Ractor.make_shareable(t)
 		end
 
@@ -613,20 +613,20 @@ describe "PG::Type derivations" do
 		end
 	end
 
-	describe PG::CompositeCoder do
+	describe YugabyteYSQL::CompositeCoder do
 		describe "Array types" do
-			let!(:textenc_string_array) { PG::TextEncoder::Array.new elements_type: textenc_string }
-			let!(:textdec_string_array) { PG::TextDecoder::Array.new elements_type: textdec_string }
-			let!(:textdec_string_array_raise) { PG::TextDecoder::Array.new elements_type: textdec_string, flags: PG::Coder:: FORMAT_ERROR_TO_RAISE }
-			let!(:textenc_int_array) { PG::TextEncoder::Array.new elements_type: textenc_int, needs_quotation: false }
-			let!(:textdec_int_array) { PG::TextDecoder::Array.new elements_type: textdec_int, needs_quotation: false }
-			let!(:textenc_float_array) { PG::TextEncoder::Array.new elements_type: textenc_float, needs_quotation: false }
-			let!(:textdec_float_array) { PG::TextDecoder::Array.new elements_type: textdec_float, needs_quotation: false }
-			let!(:textenc_timestamp_array) { PG::TextEncoder::Array.new elements_type: textenc_timestamp, needs_quotation: false }
-			let!(:textdec_timestamp_array) { PG::TextDecoder::Array.new elements_type: textdec_timestamp, needs_quotation: false }
-			let!(:textenc_string_array_with_delimiter) { PG::TextEncoder::Array.new elements_type: textenc_string, delimiter: ';' }
-			let!(:textdec_string_array_with_delimiter) { PG::TextDecoder::Array.new elements_type: textdec_string, delimiter: ';' }
-			let!(:textdec_bytea_array) { PG::TextDecoder::Array.new elements_type: textdec_bytea }
+			let!(:textenc_string_array) { YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_string }
+			let!(:textdec_string_array) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_string }
+			let!(:textdec_string_array_raise) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_string, flags: YugabyteYSQL::Coder:: FORMAT_ERROR_TO_RAISE }
+			let!(:textenc_int_array) { YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_int, needs_quotation: false }
+			let!(:textdec_int_array) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_int, needs_quotation: false }
+			let!(:textenc_float_array) { YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_float, needs_quotation: false }
+			let!(:textdec_float_array) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_float, needs_quotation: false }
+			let!(:textenc_timestamp_array) { YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_timestamp, needs_quotation: false }
+			let!(:textdec_timestamp_array) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_timestamp, needs_quotation: false }
+			let!(:textenc_string_array_with_delimiter) { YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_string, delimiter: ';' }
+			let!(:textdec_string_array_with_delimiter) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_string, delimiter: ';' }
+			let!(:textdec_bytea_array) { YugabyteYSQL::TextDecoder::Array.new elements_type: textdec_bytea }
 
 			#
 			# Array parser specs are thankfully borrowed from here:
@@ -793,12 +793,12 @@ describe "PG::Type derivations" do
 				end
 
 				it 'should decode array of types with decoder in ruby space' do
-					array_type = PG::TextDecoder::Array.new elements_type: intdec_incrementer
+					array_type = YugabyteYSQL::TextDecoder::Array.new elements_type: intdec_incrementer
 					expect( array_type.decode(%[{3,4}]) ).to eq( [4,5] )
 				end
 
 				it 'should decode array of nil types' do
-					array_type = PG::TextDecoder::Array.new elements_type: nil
+					array_type = YugabyteYSQL::TextDecoder::Array.new elements_type: nil
 					expect( array_type.decode(%[{3,4}]) ).to eq( ['3','4'] )
 				end
 			end
@@ -842,40 +842,40 @@ describe "PG::Type derivations" do
 
 				context 'array of types with encoder in ruby space' do
 					it 'encodes with quotation and default character encoding' do
-						array_type = PG::TextEncoder::Array.new elements_type: intenc_incrementer, needs_quotation: true
+						array_type = YugabyteYSQL::TextEncoder::Array.new elements_type: intenc_incrementer, needs_quotation: true
 						r = array_type.encode([3,4])
 						expect( r ).to eq( %[{"4 ","5 "}] )
 						expect( r.encoding ).to eq( Encoding::ASCII_8BIT )
 					end
 
 					it 'encodes with quotation and given character encoding' do
-						array_type = PG::TextEncoder::Array.new elements_type: intenc_incrementer, needs_quotation: true
+						array_type = YugabyteYSQL::TextEncoder::Array.new elements_type: intenc_incrementer, needs_quotation: true
 						r = array_type.encode([3,4], Encoding::CP850)
 						expect( r ).to eq( %[{"4 ","5 "}] )
 						expect( r.encoding ).to eq( Encoding::CP850 )
 					end
 
 					it 'encodes without quotation' do
-						array_type = PG::TextEncoder::Array.new elements_type: intenc_incrementer, needs_quotation: false
+						array_type = YugabyteYSQL::TextEncoder::Array.new elements_type: intenc_incrementer, needs_quotation: false
 						expect( array_type.encode([3,4]) ).to eq( %[{4 ,5 }] )
 					end
 
 					it 'encodes with default character encoding' do
-						array_type = PG::TextEncoder::Array.new elements_type: intenc_incrementer_with_encoding
+						array_type = YugabyteYSQL::TextEncoder::Array.new elements_type: intenc_incrementer_with_encoding
 						r = array_type.encode([3,4])
 						expect( r ).to eq( %[{"4 ASCII-8BIT","5 ASCII-8BIT"}] )
 						expect( r.encoding ).to eq( Encoding::ASCII_8BIT )
 					end
 
 					it 'encodes with given character encoding' do
-						array_type = PG::TextEncoder::Array.new elements_type: intenc_incrementer_with_encoding
+						array_type = YugabyteYSQL::TextEncoder::Array.new elements_type: intenc_incrementer_with_encoding
 						r = array_type.encode([3,4], Encoding::CP850)
 						expect( r ).to eq( %[{"4 CP850","5 CP850"}] )
 						expect( r.encoding ).to eq( Encoding::CP850 )
 					end
 
 					it "should raise when ruby encoder returns non string values" do
-						array_type = PG::TextEncoder::Array.new elements_type: intenc_incrementer_with_int_result, needs_quotation: false
+						array_type = YugabyteYSQL::TextEncoder::Array.new elements_type: intenc_incrementer_with_int_result, needs_quotation: false
 						expect{ array_type.encode([3,4]) }.to raise_error(TypeError)
 					end
 				end
@@ -887,12 +887,12 @@ describe "PG::Type derivations" do
 
 				context 'literal quotation' do
 					it 'should quote and escape literals' do
-						quoted_type = PG::TextEncoder::QuotedLiteral.new elements_type: textenc_string_array
+						quoted_type = YugabyteYSQL::TextEncoder::QuotedLiteral.new elements_type: textenc_string_array
 						expect( quoted_type.encode(["'A\",","\\B'"]) ).to eq( %['{"''A\\",","\\\\B''"}'] )
 					end
 
 					it 'should quote literals with correct character encoding' do
-						quoted_type = PG::TextEncoder::QuotedLiteral.new elements_type: textenc_string_array
+						quoted_type = YugabyteYSQL::TextEncoder::QuotedLiteral.new elements_type: textenc_string_array
 						v = quoted_type.encode(["Héllo"], "iso-8859-1")
 						expect( v.encoding ).to eq( Encoding::ISO_8859_1 )
 						expect( v ).to eq( %['{Héllo}'].encode(Encoding::ISO_8859_1) )
@@ -920,11 +920,11 @@ describe "PG::Type derivations" do
 			end
 
 			it "shouldn't accept invalid elements_types" do
-				expect{ PG::TextEncoder::Array.new elements_type: false }.to raise_error(TypeError)
+				expect{ YugabyteYSQL::TextEncoder::Array.new elements_type: false }.to raise_error(TypeError)
 			end
 
 			it "should have reasonable default values" do
-				t = PG::TextEncoder::Array.new
+				t = YugabyteYSQL::TextEncoder::Array.new
 				expect( t.format ).to eq( 0 )
 				expect( t.oid ).to eq( 0 )
 				expect( t.name ).to be_nil
@@ -934,7 +934,7 @@ describe "PG::Type derivations" do
 			end
 
 		it "should deny changes when frozen" do
-			t = PG::TextEncoder::Array.new.freeze
+			t = YugabyteYSQL::TextEncoder::Array.new.freeze
 			expect{ t.format = 1 }.to raise_error(FrozenError)
 			expect{ t.oid = 0  }.to raise_error(FrozenError)
 			expect{ t.name = "x" }.to raise_error(FrozenError)
@@ -944,7 +944,7 @@ describe "PG::Type derivations" do
 		end
 
 		it "should be shareable for Ractor", :ractor do
-			t = PG::TextEncoder::Array.new.freeze
+			t = YugabyteYSQL::TextEncoder::Array.new.freeze
 			Ractor.make_shareable(t)
 		end
 
@@ -955,7 +955,7 @@ describe "PG::Type derivations" do
 	end
 
 		it "should encode Strings as base64 in TextEncoder" do
-			e = PG::TextEncoder::ToBase64.new
+			e = YugabyteYSQL::TextEncoder::ToBase64.new
 			expect( e.encode("") ).to eq("")
 			expect( e.encode("x") ).to eq("eA==")
 			expect( e.encode("xx") ).to eq("eHg=")
@@ -967,14 +967,14 @@ describe "PG::Type derivations" do
 		end
 
 		it 'should encode Strings as base64 with correct character encoding' do
-			e = PG::TextEncoder::ToBase64.new
+			e = YugabyteYSQL::TextEncoder::ToBase64.new
 			v = e.encode("Héllo".encode("utf-16le"), "iso-8859-1")
 			expect( v ).to eq("SOlsbG8=")
 			expect( v.encoding ).to eq(Encoding::ISO_8859_1)
 		end
 
 		it "should encode Strings as base64 in BinaryDecoder" do
-			e = PG::BinaryDecoder::ToBase64.new
+			e = YugabyteYSQL::BinaryDecoder::ToBase64.new
 			expect( e.decode("x") ).to eq("eA==")
 			v = e.decode("Héllo".encode("utf-16le"))
 			expect( v ).to eq("SADpAGwAbABvAA==")
@@ -983,7 +983,7 @@ describe "PG::Type derivations" do
 
 		it "should encode Integers as base64" do
 			# Not really useful, but ensures that two-pass element and composite element encoders work.
-			e = PG::TextEncoder::ToBase64.new( elements_type: PG::TextEncoder::Array.new( elements_type: PG::TextEncoder::Integer.new, needs_quotation: false ))
+			e = YugabyteYSQL::TextEncoder::ToBase64.new(elements_type: YugabyteYSQL::TextEncoder::Array.new(elements_type: YugabyteYSQL::TextEncoder::Integer.new, needs_quotation: false ))
 			expect( e.encode([1]) ).to eq(["{1}"].pack("m").chomp)
 			expect( e.encode([12]) ).to eq(["{12}"].pack("m").chomp)
 			expect( e.encode([123]) ).to eq(["{123}"].pack("m").chomp)
@@ -994,7 +994,7 @@ describe "PG::Type derivations" do
 		end
 
 		it "should decode base64 to Strings in TextDecoder" do
-			e = PG::TextDecoder::FromBase64.new
+			e = YugabyteYSQL::TextDecoder::FromBase64.new
 			expect( e.decode("") ).to eq("")
 			expect( e.decode("eA==") ).to eq("x")
 			expect( e.decode("eHg=") ).to eq("xx")
@@ -1006,16 +1006,16 @@ describe "PG::Type derivations" do
 		end
 
 		it "should decode base64 in BinaryEncoder" do
-			e = PG::BinaryEncoder::FromBase64.new
+			e = YugabyteYSQL::BinaryEncoder::FromBase64.new
 			expect( e.encode("eA==") ).to eq("x")
 
-			e = PG::BinaryEncoder::FromBase64.new( elements_type: PG::TextEncoder::Integer.new )
+			e = YugabyteYSQL::BinaryEncoder::FromBase64.new(elements_type: YugabyteYSQL::TextEncoder::Integer.new )
 			expect( e.encode(124) ).to eq("124=".unpack("m")[0])
 		end
 
 		it "should decode base64 to Integers" do
 			# Not really useful, but ensures that composite element encoders work.
-			e = PG::TextDecoder::FromBase64.new( elements_type: PG::TextDecoder::Array.new( elements_type: PG::TextDecoder::Integer.new ))
+			e = YugabyteYSQL::TextDecoder::FromBase64.new(elements_type: YugabyteYSQL::TextDecoder::Array.new(elements_type: YugabyteYSQL::TextDecoder::Integer.new ))
 			expect( e.decode(["{1}"].pack("m")) ).to eq([1])
 			expect( e.decode(["{12}"].pack("m")) ).to eq([12])
 			expect( e.decode(["{123}"].pack("m")) ).to eq([123])
@@ -1025,12 +1025,12 @@ describe "PG::Type derivations" do
 			expect( e.decode(["{1234567}"].pack("m")) ).to eq([1234567])
 			expect( e.decode(["{12345678}"].pack("m")) ).to eq([12345678])
 
-			e = PG::TextDecoder::FromBase64.new( elements_type: PG::BinaryDecoder::Integer.new )
+			e = YugabyteYSQL::TextDecoder::FromBase64.new(elements_type: YugabyteYSQL::BinaryDecoder::Integer.new )
 			expect( e.decode("ALxhTg==") ).to eq(12345678)
 		end
 
 		it "should decode base64 with garbage" do
-			e = PG::TextDecoder::FromBase64.new format: 1
+			e = YugabyteYSQL::TextDecoder::FromBase64.new format: 1
 			expect( e.decode("=") ).to eq("=".unpack("m")[0])
 			expect( e.decode("==") ).to eq("==".unpack("m")[0])
 			expect( e.decode("===") ).to eq("===".unpack("m")[0])
@@ -1054,15 +1054,15 @@ describe "PG::Type derivations" do
 		end
 	end
 
-	describe PG::CopyCoder do
-		describe PG::TextEncoder::CopyRow do
+	describe YugabyteYSQL::CopyCoder do
+		describe YugabyteYSQL::TextEncoder::CopyRow do
 			context "with default typemap" do
 				let!(:encoder) do
-					PG::TextEncoder::CopyRow.new
+					YugabyteYSQL::TextEncoder::CopyRow.new
 				end
 
 				it "should deny changes when frozen" do
-					t = PG::TextEncoder::CopyRow.new.freeze
+					t = YugabyteYSQL::TextEncoder::CopyRow.new.freeze
 					expect{ t.format = 1 }.to raise_error(FrozenError)
 					expect{ t.oid = 0  }.to raise_error(FrozenError)
 					expect{ t.name = "x" }.to raise_error(FrozenError)
@@ -1072,7 +1072,7 @@ describe "PG::Type derivations" do
 				end
 
 				it "should be shareable for Ractor", :ractor do
-					t = PG::TextEncoder::CopyRow.new.freeze
+					t = YugabyteYSQL::TextEncoder::CopyRow.new.freeze
 					Ractor.make_shareable(t)
 				end
 
@@ -1094,14 +1094,14 @@ describe "PG::Type derivations" do
 
 			context "with TypeMapByClass" do
 				let!(:tm) do
-					tm = PG::TypeMapByClass.new
+					tm = YugabyteYSQL::TypeMapByClass.new
 					tm[Integer] = textenc_int
 					tm[Float] = intenc_incrementer
-					tm[Array] = PG::TextEncoder::Array.new elements_type: textenc_string
+					tm[Array] = YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_string
 					tm
 				end
 				let!(:encoder) do
-					PG::TextEncoder::CopyRow.new type_map: tm
+					YugabyteYSQL::TextEncoder::CopyRow.new type_map: tm
 				end
 
 				it "should have reasonable default values" do
@@ -1114,13 +1114,13 @@ describe "PG::Type derivations" do
 					encoder.name = "test"
 					encoder.delimiter = "#"
 					encoder.null_string = "NULL"
-					encoder.type_map = PG::TypeMapByColumn.new []
+					encoder.type_map = YugabyteYSQL::TypeMapByColumn.new []
 					encoder2 = encoder.dup
 					expect( encoder.object_id ).to_not eq( encoder2.object_id )
 					expect( encoder2.name ).to eq( "test" )
 					expect( encoder2.delimiter ).to eq( "#" )
 					expect( encoder2.null_string ).to eq( "NULL" )
-					expect( encoder2.type_map ).to be_a_kind_of( PG::TypeMapByColumn )
+					expect( encoder2.type_map ).to be_a_kind_of(YugabyteYSQL::TypeMapByColumn )
 				end
 
 				describe '#encode' do
@@ -1144,10 +1144,10 @@ describe "PG::Type derivations" do
 			end
 		end
 
-		describe PG::BinaryEncoder::CopyRow do
+		describe YugabyteYSQL::BinaryEncoder::CopyRow do
 			context "with default typemap" do
 				let!(:encoder) do
-					PG::BinaryEncoder::CopyRow.new
+					YugabyteYSQL::BinaryEncoder::CopyRow.new
 				end
 
 				it "should encode different types of Ruby objects" do
@@ -1164,13 +1164,13 @@ describe "PG::Type derivations" do
 
 			context "with TypeMapByClass" do
 				let!(:tm) do
-					tm = PG::TypeMapByClass.new
+					tm = YugabyteYSQL::TypeMapByClass.new
 					tm[Integer] = binaryenc_int4
 					tm[Float] = intenc_incrementer
 					tm
 				end
 				let!(:encoder) do
-					PG::BinaryEncoder::CopyRow.new type_map: tm
+					YugabyteYSQL::BinaryEncoder::CopyRow.new type_map: tm
 				end
 
 				it "should have reasonable default values" do
@@ -1179,11 +1179,11 @@ describe "PG::Type derivations" do
 
 				it "copies all attributes with #dup" do
 					encoder.name = "test"
-					encoder.type_map = PG::TypeMapByColumn.new []
+					encoder.type_map = YugabyteYSQL::TypeMapByColumn.new []
 					encoder2 = encoder.dup
 					expect( encoder.object_id ).to_not eq( encoder2.object_id )
 					expect( encoder2.name ).to eq( "test" )
-					expect( encoder2.type_map ).to be_a_kind_of( PG::TypeMapByColumn )
+					expect( encoder2.type_map ).to be_a_kind_of(YugabyteYSQL::TypeMapByColumn )
 				end
 
 				it "should encode different types of Ruby objects" do
@@ -1195,10 +1195,10 @@ describe "PG::Type derivations" do
 			end
 		end
 
-		describe PG::TextDecoder::CopyRow do
+		describe YugabyteYSQL::TextDecoder::CopyRow do
 			context "with default typemap" do
 				let!(:decoder) do
-					PG::TextDecoder::CopyRow.new
+					YugabyteYSQL::TextDecoder::CopyRow.new
 				end
 
 				describe '#decode' do
@@ -1217,10 +1217,10 @@ describe "PG::Type derivations" do
 
 			context "with TypeMapByColumn" do
 				let!(:tm) do
-					PG::TypeMapByColumn.new [textdec_int, textdec_string, intdec_incrementer, nil]
+					YugabyteYSQL::TypeMapByColumn.new [textdec_int, textdec_string, intdec_incrementer, nil]
 				end
 				let!(:decoder) do
-					PG::TextDecoder::CopyRow.new type_map: tm
+					YugabyteYSQL::TextDecoder::CopyRow.new type_map: tm
 				end
 
 				it "should give account about memory usage" do
@@ -1235,10 +1235,10 @@ describe "PG::Type derivations" do
 			end
 		end
 
-		describe PG::BinaryDecoder::CopyRow do
+		describe YugabyteYSQL::BinaryDecoder::CopyRow do
 			context "with default typemap" do
 				let!(:decoder) do
-					PG::BinaryDecoder::CopyRow.new
+					YugabyteYSQL::BinaryDecoder::CopyRow.new
 				end
 
 				describe '#decode' do
@@ -1279,10 +1279,10 @@ describe "PG::Type derivations" do
 
 			context "with TypeMapByColumn" do
 				let!(:tm) do
-					PG::TypeMapByColumn.new [binarydec_integer, binarydec_string, intdec_incrementer, nil]
+					YugabyteYSQL::TypeMapByColumn.new [binarydec_integer, binarydec_string, intdec_incrementer, nil]
 				end
 				let!(:decoder) do
-					PG::BinaryDecoder::CopyRow.new type_map: tm
+					YugabyteYSQL::BinaryDecoder::CopyRow.new type_map: tm
 				end
 
 				describe '#decode' do
@@ -1295,15 +1295,15 @@ describe "PG::Type derivations" do
 		end
 	end
 
-	describe PG::RecordCoder do
-		describe PG::TextEncoder::Record do
+	describe YugabyteYSQL::RecordCoder do
+		describe YugabyteYSQL::TextEncoder::Record do
 			context "with default typemap" do
 				let!(:encoder) do
-					PG::TextEncoder::Record.new
+					YugabyteYSQL::TextEncoder::Record.new
 				end
 
 				it "should deny changes when frozen" do
-					t = PG::TextEncoder::Record.new.freeze
+					t = YugabyteYSQL::TextEncoder::Record.new.freeze
 					expect{ t.format = 1 }.to raise_error(FrozenError)
 					expect{ t.oid = 0  }.to raise_error(FrozenError)
 					expect{ t.name = "x" }.to raise_error(FrozenError)
@@ -1311,7 +1311,7 @@ describe "PG::Type derivations" do
 				end
 
 				it "should be shareable for Ractor", :ractor do
-					t = PG::TextEncoder::Record.new.freeze
+					t = YugabyteYSQL::TextEncoder::Record.new.freeze
 					Ractor.make_shareable(t)
 				end
 
@@ -1333,14 +1333,14 @@ describe "PG::Type derivations" do
 
 			context "with TypeMapByClass" do
 				let!(:tm) do
-					tm = PG::TypeMapByClass.new
+					tm = YugabyteYSQL::TypeMapByClass.new
 					tm[Integer] = textenc_int
 					tm[Float] = intenc_incrementer
-					tm[Array] = PG::TextEncoder::Array.new elements_type: textenc_string
+					tm[Array] = YugabyteYSQL::TextEncoder::Array.new elements_type: textenc_string
 					tm
 				end
 				let!(:encoder) do
-					PG::TextEncoder::Record.new type_map: tm
+					YugabyteYSQL::TextEncoder::Record.new type_map: tm
 				end
 
 				it "should have reasonable default values" do
@@ -1349,11 +1349,11 @@ describe "PG::Type derivations" do
 
 				it "copies all attributes with #dup" do
 					encoder.name = "test"
-					encoder.type_map = PG::TypeMapByColumn.new []
+					encoder.type_map = YugabyteYSQL::TypeMapByColumn.new []
 					encoder2 = encoder.dup
 					expect( encoder.object_id ).to_not eq( encoder2.object_id )
 					expect( encoder2.name ).to eq( "test" )
-					expect( encoder2.type_map ).to be_a_kind_of( PG::TypeMapByColumn )
+					expect( encoder2.type_map ).to be_a_kind_of(YugabyteYSQL::TypeMapByColumn )
 				end
 
 				describe '#encode' do
@@ -1371,10 +1371,10 @@ describe "PG::Type derivations" do
 			end
 		end
 
-		describe PG::TextDecoder::Record do
+		describe YugabyteYSQL::TextDecoder::Record do
 			context "with default typemap" do
 				let!(:decoder) do
-					PG::TextDecoder::Record.new
+					YugabyteYSQL::TextDecoder::Record.new
 				end
 
 				it "should give account about memory usage" do
@@ -1403,10 +1403,10 @@ describe "PG::Type derivations" do
 
 			context "with TypeMapByColumn" do
 				let!(:tm) do
-					PG::TypeMapByColumn.new [textdec_int, textdec_string, intdec_incrementer, nil]
+					YugabyteYSQL::TypeMapByColumn.new [textdec_int, textdec_string, intdec_incrementer, nil]
 				end
 				let!(:decoder) do
-					PG::TextDecoder::Record.new type_map: tm
+					YugabyteYSQL::TextDecoder::Record.new type_map: tm
 				end
 
 				describe '#decode' do

--- a/spec/yugabyte_ysql_spec.rb
+++ b/spec/yugabyte_ysql_spec.rb
@@ -3,53 +3,53 @@
 
 require_relative 'helpers'
 
-require 'pg'
+require 'yugabyte_ysql'
 
-describe PG do
+describe YugabyteYSQL do
 
 	it "knows what version of the libpq library is loaded" do
-		expect( PG.library_version ).to be_an( Integer )
-		expect( PG.library_version ).to be >= 90100
+		expect(YugabyteYSQL.library_version ).to be_an(Integer )
+		expect(YugabyteYSQL.library_version ).to be >= 90100
 	end
 
 	it "can format the pg version" do
-		expect( PG.version_string ).to be_an( String )
-		expect( PG.version_string ).to match(/PG \d+\.\d+\.\d+/)
-		expect( PG.version_string(true) ).to be_an( String )
-		expect( PG.version_string(true) ).to match(/PG \d+\.\d+\.\d+/)
+		expect(YugabyteYSQL.version_string ).to be_an(String )
+		expect(YugabyteYSQL.version_string ).to match(/PG \d+\.\d+\.\d+/)
+		expect(YugabyteYSQL.version_string(true) ).to be_an(String )
+		expect(YugabyteYSQL.version_string(true) ).to match(/PG \d+\.\d+\.\d+/)
 	end
 
 	it "can select which of both security libraries to initialize" do
 		# This setting does nothing here, because there is already a connection
 		# to the server, at this point in time.
-		PG.init_openssl(false, true)
-		PG.init_openssl(1, 0)
+		YugabyteYSQL.init_openssl(false, true)
+		YugabyteYSQL.init_openssl(1, 0)
 	end
 
 	it "can select whether security libraries to initialize" do
 		# This setting does nothing here, because there is already a connection
 		# to the server, at this point in time.
-		PG.init_ssl(false)
-		PG.init_ssl(1)
+		YugabyteYSQL.init_ssl(false)
+		YugabyteYSQL.init_ssl(1)
 	end
 
 
 	it "knows whether or not the library is threadsafe" do
-		expect( PG ).to be_threadsafe()
+		expect(YugabyteYSQL ).to be_threadsafe()
 	end
 
 	it "tells about the libpq library path" do
-		expect( PG::POSTGRESQL_LIB_PATH ).to include("/")
+		expect(YugabyteYSQL::POSTGRESQL_LIB_PATH ).to include("/")
 	end
 
 	it "can #connect" do
-		c = PG.connect(@conninfo)
-		expect( c ).to be_a_kind_of( PG::Connection )
+		c = YugabyteYSQL.connect(@conninfo)
+		expect( c ).to be_a_kind_of(YugabyteYSQL::Connection )
 		c.close
 	end
 
 	it "can #connect with block" do
-		bres = PG.connect(@conninfo) do |c|
+		bres = YugabyteYSQL.connect(@conninfo) do |c|
 			res = c.exec "SELECT 5"
 			expect( res.values ).to eq( [["5"]] )
 			55

--- a/yugabyte_ysql.gemspec
+++ b/yugabyte_ysql.gemspec
@@ -4,20 +4,20 @@
 require_relative 'lib/pg/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "pg"
-  spec.version       = PG::VERSION
-  spec.authors       = ["Michael Granger", "Lars Kanis"]
-  spec.email         = ["ged@FaerieMUD.org", "lars@greiz-reinsdorf.de"]
+  spec.name          = "yugabyte_ysql"
+  spec.version       = YugabyteYSQL::VERSION
+  spec.authors       = ["Michael Granger", "Lars Kanis", "YugabyteDB Dev Team"]
+  spec.email         = ["ged@FaerieMUD.org", "lars@greiz-reinsdorf.de", "info@yugabyte.com"]
 
-  spec.summary       = "Pg is the Ruby interface to the PostgreSQL RDBMS"
-  spec.description   = "Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later."
-  spec.homepage      = "https://github.com/ged/ruby-pg"
+  spec.summary       = "The Ruby interface to YugabyteDB, based on PG Ruby Driver v#{YugabyteYSQL::PG_VERSION}"
+  spec.description   = "Pg_YugabyteDB is the Ruby interface to the PostgreSQL-compatible YugabyteDB. It works with YugabyteDB 2.20 and later."
+  spec.homepage      = "https://github.com/yugabyte/ruby-pg"
   spec.license       = "BSD-2-Clause"
   spec.required_ruby_version = ">= 2.5"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/ged/ruby-pg"
-  spec.metadata["changelog_uri"] = "https://github.com/ged/ruby-pg/blob/master/History.md"
+  spec.metadata["source_code_uri"] = "https://github.com/yugabyte/ruby-pg"
+  spec.metadata["changelog_uri"] = "https://github.com/yugabyte/ruby-pg/blob/master/History.md"
   spec.metadata["documentation_uri"] = "http://deveiate.org/code/pg"
 
   # Specify which files should be added to the gem when it is released.
@@ -27,8 +27,7 @@ Gem::Specification.new do |spec|
   end
   spec.extensions    = ["ext/extconf.rb"]
   spec.require_paths = ["lib"]
-  spec.cert_chain    = ["certs/ged.pem"]
   spec.rdoc_options  = ["--main", "README.md",
-                        "--title", "PG: The Ruby PostgreSQL Driver"]
+                        "--title", "YugabyteYSQL: The Ruby Driver for YugabyteDB (YSQL)"]
   spec.extra_rdoc_files = `git ls-files -z *.rdoc *.md lib/*.rb lib/*/*.rb lib/*/*/*.rb ext/*.c ext/*.h`.split("\x0")
 end


### PR DESCRIPTION
- This change ensures Ruby Smart driver uses a different module name from that of PG driver
- Change all references to `PG` module to `YugabyteYSQL` module (`require 'pg'` -> `require 'yugabyte_ysql'`)
- Rename `pg.gemspec` to `yugabyte_ysql.gemspec`