### PR TITLE
[CE577] Invoke PQconsumeInput() multiple times to ensure all bytes are read

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2453,6 +2453,15 @@ wait_socket_readable( VALUE self, struct timeval *ptimeout, void *(*is_readable)
 			pgconn_close_socket_io(self);
 			pg_raise_conn_error(rb_eConnectionBad, self, "PQconsumeInput() %s", PQerrorMessage(conn));
 		}
+
+		if (PQsslInUse(conn)) {
+			for (int i = 0; i < 15; i++) {
+				if ( PQconsumeInput(conn) == 0 ) {
+					pgconn_close_socket_io(self);
+					pg_raise_conn_error(rb_eConnectionBad, self, "PQconsumeInput() %s", PQerrorMessage(conn));
+				}
+			}
+		}
 	}
 
 	return retval;

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2458,7 +2458,7 @@ wait_socket_readable( VALUE self, struct timeval *ptimeout, void *(*is_readable)
 			for (int i = 0; i < 15; i++) {
 				if ( PQconsumeInput(conn) == 0 ) {
 					pgconn_close_socket_io(self);
-					pg_raise_conn_error(rb_eConnectionBad, self, "PQconsumeInput() %s", PQerrorMessage(conn));
+					pg_raise_conn_error(rb_eConnectionBad, self, "PQconsumeInput() #%d - %s", i, PQerrorMessage(conn));
 				}
 			}
 		}


### PR DESCRIPTION
- Invoke `PQconsumeInput()` multiple times to ensure all bytes are read, in case of a ssl/tls connection.
- This is a fix for hang in a query with a specific result-size
- More details
  - For a specific result size, the `pg_rb_io_wait()` waits for more data even though it has received all the data. And the query gets stuck.
  - By invoking `PQconsumeInput()` multiple times, we attempt to read all the data available in the same while loop
  - Slack discussion: https://yugabyte.slack.com/archives/C07FAJZJJHZ/p1723522333087219
  - The additional time for these calls is observed to be around 1/4th of a millisecond.
  - The more precise fix - consuming only till there are non-zero bytes available - requires accessing pointers of the connection buffer. Or knowing how many bytes were read. The API which does this is internal to the lib/pq and hence could not be accessed from the ruby driver.

### Testing
- Tested with a sample application which fails without the fix. Added through a separate PR (see below).
- Also, ran all the tests in the repo (`rake test`)