### PR TITLE
Add support to identify read-replica nodes during connection creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ The driver attempts connection to servers in the first fallback placement(s) if 
 then it attempts to connect to servers in the second fallback placement(s), if specified. This continues until the driver finds a server to connect to, else an error is returned to the application.
 And this repeats for each connection request.
 
-### Limitations
+### Using with ActiveRecord
 
-- The load balancing feature of the Ruby Smart driver for YugabyteDB does not work with ActiveRecords - the ORM tool for Ruby apps.
+- The load balancing feature of the Ruby Smart driver for YugabyteDB can be used with ActiveRecord - the ORM tool for Ruby apps - via its [adapter for YugabyteDB](https://github.com/yugabyte/activerecord-yugabytedb-adapter).
 
 Rest of the README is from upstream repository.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ This is similar to 'Cluster Awareness' but uses those servers which are part of 
 
 ### Connection Properties added for load balancing
 
-- _load_balance_   - It expects **true/false** as its possible values. The 'load_balance' property needs to be set to 'true' to enable cluster-awareness.
+- _load_balance_ - Starting with version 0.6, it expects one of **false, any (same as true), only-primary, only-rr, prefer-primary and prefer-rr** as its possible values. The default value for _load_balance_ property is `false`.
+  - _false_ - No connection load balancing. Behaviour is similar to vanilla ruby-pg driver
+  - _any_ - Same as value _true_. Distribute connections equally across all nodes in the cluster, irrespective of its type (`primary` or `read-replica`)
+  - _only-primary_ - Create connections equally across only the primary nodes of the cluster
+  - _only-rr_ - Create connections equally across only the read-replica nodes of the cluster
+  - _prefer-primary_ - Create connections equally across primary cluster nodes. If none available, on any available read replica node in the cluster
+  - _prefer-rr_ - Create connections equally across read replica nodes of the cluster. If none available, on any available primary cluster node
 - _topology_keys_  - It takes a comma separated geo-location values. A single geo-location can be given as 'cloud.region.zone'. Multiple geo-locations too can be specified, separated by comma (`,`). Optionally, you can also register your preference for particular geo-locations by appending the preference value with prefix `:`. For example, `cloud.regionA.zoneA:1,cloud.regionA.zoneB:2`.
 - _yb_servers_refresh_interval_ - Minimum time interval, in seconds, between two attempts to refresh the information about cluster nodes. This is checked only when a new connection is requested. Default is 300. Valid values are integers between 0 and 600. Value 0 means refresh for each connection request. Any value outside this range is ignored and the default is used.
 - _fallback_to_topology_keys_only_ - When set to true, the driver does not attempt to connect to nodes outside of the geo-locations specified via _topology_keys_. Default value is false.

--- a/lib/ysql/connection.rb
+++ b/lib/ysql/connection.rb
@@ -848,6 +848,7 @@ class YSQL::Connection
 		end
 
 		private def connect_to_hosts(*args)
+			puts "connect_to_hosts(): args = #{args}"
 			option_string, lb_properties = parse_connect_args_and_return_lb_props(*args)
 			iopts = YSQL::Connection.conninfo_parse(option_string).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
 			iopts = YSQL::Connection.conndefaults.each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }.merge(iopts)

--- a/lib/ysql/connection.rb
+++ b/lib/ysql/connection.rb
@@ -848,7 +848,6 @@ class YSQL::Connection
 		end
 
 		private def connect_to_hosts(*args)
-			puts "connect_to_hosts(): args = #{args}"
 			option_string, lb_properties = parse_connect_args_and_return_lb_props(*args)
 			iopts = YSQL::Connection.conninfo_parse(option_string).each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }
 			iopts = YSQL::Connection.conndefaults.each_with_object({}){|h, o| o[h[:keyword].to_sym] = h[:val] if h[:val] }.merge(iopts)

--- a/lib/ysql/load_balance_service.rb
+++ b/lib/ysql/load_balance_service.rb
@@ -256,12 +256,12 @@ class YSQL::LoadBalanceService
     end
 
     if allowed_placements.nil? || (selected.empty? && !fallback_to_tk_only) # cluster-aware || fallback_to_tk_only = false
-      unless allowed_placements.nil?
-      end
+      # unless allowed_placements.nil?
+      # end
       min_connections = 1000000 # Using some really high value
       selected = Array.new
       @@cluster_info.each do |host, node_info|
-        unless node_info.is_down
+        if !node_info.is_down && is_node_type_acceptable(node_info.node_type, lb_value, strict_preference)
           if node_info.count < min_connections
             min_connections = node_info.count
             selected.clear
@@ -279,10 +279,11 @@ class YSQL::LoadBalanceService
       index = rand(selected.size)
       selected_node = selected[index]
       @@cluster_info[selected_node].count += 1
+      selected_port = @@cluster_info[selected_node].port
       if !@@useHostColumn.nil? && !@@useHostColumn
         selected_node = @@cluster_info[selected_node].public_ip
       end
-      Array[selected_node, @@cluster_info[selected_node].port, current_index]
+      Array[selected_node, selected_port, current_index]
     end
   end
 

--- a/lib/ysql/version.rb
+++ b/lib/ysql/version.rb
@@ -1,5 +1,5 @@
 module YSQL
 	# Library version
 	PG_VERSION = '1.5.6'
-	VERSION = '0.5'
+	VERSION = '0.6'
 end


### PR DESCRIPTION
## What
- Add support to identify read-replica nodes during connection creation
- Added log statements

## How
- The property `load_balance` now accepts new values `any`, `only-primary`, `prefer-primary`, `only-rr` and `prefer-primary`, in addition to existing `true` and `false`. The driver uses this value to determine the the type of node to connect to.

## Testing
- Added test cases in [this PR](https://github.com/yugabyte/driver-examples/pull/45)