### PR TITLE
Include logger dependency in the driver's Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem "rdoc", "~> 6.4"
   gem "rspec", "~> 3.5"
   gem 'concurrent-ruby', require: 'concurrent'
+  gem 'logger'
   # "bigdecimal" is a gem on ruby-3.4+ and it's optional for ruby-pg.
   # Specs should succeed without it, but 4 examples are then excluded.
   # gem "bigdecimal", "~> 3.0"

--- a/lib/ysql/load_balance_service.rb
+++ b/lib/ysql/load_balance_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'ysql' unless defined?( YSQL )
 require 'concurrent'
+require 'logger'
 
 class YSQL::LoadBalanceService
 

--- a/lib/ysql/version.rb
+++ b/lib/ysql/version.rb
@@ -1,5 +1,5 @@
 module YSQL
 	# Library version
 	PG_VERSION = '1.5.6'
-	VERSION = '0.6'
+	VERSION = '0.7'
 end


### PR DESCRIPTION
- Include logger gem in the driver's Gemfile
- Its absence was causing the tests to fail on Jenkins
- The [Jenkins now runs without issues](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/237/execution/node/276/log/) due to logger lib